### PR TITLE
Bump version to 1.0.0-beta.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,7 @@ docker:
 	.
 
 .PHONY: deb-pkg
+deb-pkg: VERSION=1.0.0-beta.2
 deb-pkg:
-	@dpkg-deb --root-owner-group -Z gzip --build debian flecs-webapp.deb
+	@sed -i 's/Version:.*/Version: ${VERSION}/g' debian/DEBIAN/control
+	@dpkg-deb --root-owner-group -Z gzip --build debian flecs-webapp_${VERSION}_all.deb

--- a/debian/DEBIAN/control
+++ b/debian/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: flecs-webapp
-Version: 1.0.0-beta.1
+Version:
 Description: FLECS App Management Web App
 Architecture: all
 Priority: optional

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "FLECS WebApp",
   "keywords": [
     "react",


### PR DESCRIPTION
Parameterize version in package, and set it via Makefile. Allows
using the current version in the package name itself as well as
its metadata in DEBIAN/control