### PR TITLE
Service: Fix VM shutdown issue

### DIFF
--- a/debian/etc/systemd/system/flecs-webapp.service
+++ b/debian/etc/systemd/system/flecs-webapp.service
@@ -4,6 +4,8 @@ After=network-online.target
 Wants=network-online.target
 After=docker.service
 Requires=docker.service
+After=containerd.service
+Wants=containerd.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
The beta VM (as well as all more recent Debian versions) blocks
on shutdown, "waiting for containerd-shim". By making the webapp
optionally depend on containerd.service, this issue is solved
while maintaining compatibility with older Debian versions where
this service does not exist.