### PR TITLE
Convert data at the service mesh from base64 to ascii

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -50,7 +50,7 @@ export default function DataTable (props) {
 
   function createData (key, value, encoding, timestamp) {
     let dataValue = value
-    if (encoding === 'application/octet') {
+    if (encoding === 'application/octet-stream') {
       dataValue = Buffer
         .from(value, 'base64')
         .toString('ascii')

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -49,7 +49,13 @@ export default function DataTable (props) {
   ]
 
   function createData (key, value, encoding, timestamp) {
-    return { key, value, encoding, timestamp }
+    let dataValue = value
+    if (encoding === 'application/octet') {
+      dataValue = Buffer
+        .from(value, 'base64')
+        .toString('ascii')
+    }
+    return { key, dataValue, encoding, timestamp }
   }
 
   if (props.data && props.data.length > 0) {

--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -48,14 +48,15 @@ export default function DataTable (props) {
     }
   ]
 
-  function createData (key, value, encoding, timestamp) {
-    let dataValue = value
+  function createData (key, dataValue, encoding, timestamp) {
+    let value = dataValue
     if (encoding === 'application/octet-stream') {
-      dataValue = Buffer
+      value = Buffer
         .from(value, 'base64')
         .toString('ascii')
     }
-    return { key, dataValue, encoding, timestamp }
+
+    return { key, value, encoding, timestamp }
   }
 
   if (props.data && props.data.length > 0) {

--- a/src/components/__tests__/DataTable.test.js
+++ b/src/components/__tests__/DataTable.test.js
@@ -32,6 +32,12 @@ const testData = [
     value: 'abc',
     encoding: 'plain/json',
     timestamp: '2022-03-11'
+  },
+  {
+    key: 'root/app/3',
+    value: 'SGVsbG8gV29ybGQh',
+    encoding: 'application/octet-stream',
+    timestamp: '2022-03-13'
   }
 ]
 describe('DataTable', () => {
@@ -43,5 +49,6 @@ describe('DataTable', () => {
     expect(screen.getByText('plain/text')).toBeVisible()
     expect(screen.getByText('2022-03-12')).toBeVisible()
     expect(screen.getByText('root/app/2')).toBeVisible()
+    expect(screen.getByText('Hello World!')).toBeVisible()
   })
 })


### PR DESCRIPTION
All data which comes in as application/octet-stream is encoded in base64. To make it readable, it is converted to ascii before it is put into the data table.