### PR TITLE
Enable app instances to access devices such as usb

### DIFF
--- a/src/api/VersionService.js
+++ b/src/api/VersionService.js
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Wed Jun 01 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import axios from 'axios'
+import { DeviceAPIConfiguration } from './api-config'
+
+async function getVersion () {
+  return axios
+    .get(DeviceAPIConfiguration.TARGET + DeviceAPIConfiguration.GET_VERSION_URL)
+    .then(response => {
+      return response.data
+    })
+    .catch(error => {
+      return Promise.reject(error)
+    })
+}
+
+export { getVersion }

--- a/src/api/__mocks__/VersionService.js
+++ b/src/api/__mocks__/VersionService.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Wed Jun 01 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+async function getVersion () {
+  return new Promise((resolve, reject) => {
+    resolve(
+      {
+        core: '1.1.0-porpoise-475591c'
+      }
+    )
+  })
+}
+
+export { getVersion }

--- a/src/api/__tests__/VersionService.test.js
+++ b/src/api/__tests__/VersionService.test.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Wed Jun 01 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import '@testing-library/dom'
+import { waitFor } from '@testing-library/react'
+import { act } from 'react-dom/test-utils'
+import axios from 'axios'
+import { getVersion } from '../VersionService'
+
+jest.mock('axios')
+
+const mockVersion = {
+  data: {
+    core: '1.1.0-porpoise-475591c'
+  }
+}
+
+describe('VersionService', () => {
+  beforeAll(() => {
+    axios.get = jest.fn()
+  })
+
+  afterAll(() => {
+    jest.resetAllMocks()
+  })
+  test('calls successfull getVersion', async () => {
+    axios.get.mockResolvedValueOnce(mockVersion)
+    const version = await waitFor(() => getVersion())
+
+    expect(version.core).toBe(mockVersion.data.core)
+  })
+
+  test('calls unsuccessfull getVersion', async () => {
+    axios.get.mockRejectedValueOnce(new Error('Failed to load config details'))
+    await act(async () => {
+      expect(getVersion()).rejects.toThrowError()
+    })
+  })
+})

--- a/src/api/api-config.js
+++ b/src/api/api-config.js
@@ -27,6 +27,7 @@ const DATA_LAYER_ROUTE = '/data-layer'
 const GET_INSTALLED_APP_LIST_URL = '/list'
 const GET_BROWSE_DATA_LAYER = '/browse'
 const GET_PING_URL = DEVICE_ROUTE + SYSTEM_ROUTE + '/ping'
+const GET_VERSION_URL = DEVICE_ROUTE + SYSTEM_ROUTE + '/version'
 
 const POST_INSTALL_APP_URL = '/install'
 const POST_UNINSTALL_APP_URL = '/uninstall'
@@ -151,6 +152,10 @@ class DeviceAPIConfiguration extends Component {
 
   static get GET_PING_URL () {
     return GET_PING_URL
+  }
+
+  static get GET_VERSION_URL () {
+    return GET_VERSION_URL
   }
 
   // put requests

--- a/src/components/AppBar.js
+++ b/src/components/AppBar.js
@@ -36,6 +36,7 @@ import AuthService from '../api/AuthService'
 import LoginIcon from '@mui/icons-material/Login'
 import PersonIcon from '@mui/icons-material/Person'
 import { useNavigate } from 'react-router-dom'
+import { useEffectOnce } from './useEffectOnce'
 
 function ElevationScroll (props) {
   const { children, window } = props
@@ -62,7 +63,7 @@ export default function ElevateAppBar (props) {
   const user = useAuth()
   const navigate = useNavigate()
 
-  React.useEffect(() => {
+  useEffectOnce(() => {
   }, [user])
 
   const handleMenu = (event) => {

--- a/src/components/AuthProvider.js
+++ b/src/components/AuthProvider.js
@@ -20,6 +20,7 @@ import PropTypes from 'prop-types'
 import AuthService from '../api/AuthService'
 import { Navigate, Outlet, useLocation } from 'react-router-dom'
 import { postMPLogin } from '../api/DeviceAuthAPI'
+import { useEffectOnce } from './useEffectOnce'
 
 let SET_USER
 
@@ -38,7 +39,7 @@ const userReducer = (state, action) => {
 }
 
 function AuthProvider (props) {
-  React.useEffect(() => {
+  useEffectOnce(() => {
     validateUser()
   })
 

--- a/src/components/InstallApp.js
+++ b/src/components/InstallApp.js
@@ -24,6 +24,7 @@ import React from 'react'
 import AppAPI from '../api/AppAPI'
 import { ReferenceDataContext } from '../data/ReferenceDataContext'
 import { setLicensedApp } from '../api/LicenseService'
+import { useEffectOnce } from './useEffectOnce'
 
 export default function InstallApp (props) {
   const { install, app, tickets } = (props)
@@ -71,7 +72,7 @@ export default function InstallApp (props) {
     setInstalling(false)
   })
 
-  React.useEffect(() => {
+  useEffectOnce(() => {
     if (tickets?.length > 0 && app && install && !installing && (!success || !error)) {
       setRetry(false)
       installApp(app)

--- a/src/components/InstanceConfig.js
+++ b/src/components/InstanceConfig.js
@@ -128,10 +128,10 @@ export default function InstanceConfig (props) {
         </Box>
 
         <TabPanel value="1">
-          <NICConfig nicConfig={instanceConfig} setNicConfig={setInstanceConfig} setConfigChanged={setConfigChanged} saveConfig={setSaveConfig}></NICConfig>
+          <NICConfig testID='nic-config' nicConfig={instanceConfig} setNicConfig={setInstanceConfig} setConfigChanged={setConfigChanged} saveConfig={setSaveConfig}></NICConfig>
         </TabPanel>
         <TabPanel value="2">
-          <InstanceDevicesConfig instanceConfig={instanceConfig} setDevicesConfig={setInstanceConfig} setConfigChanged={setConfigChanged} saveConfig={setSaveConfig} ></InstanceDevicesConfig>
+          <InstanceDevicesConfig testID='devices-config' instanceConfig={instanceConfig} setDevicesConfig={setInstanceConfig} setConfigChanged={setConfigChanged} saveConfig={setSaveConfig} ></InstanceDevicesConfig>
         </TabPanel>
       </TabContext>}
   </Box>)

--- a/src/components/InstanceDetails.js
+++ b/src/components/InstanceDetails.js
@@ -22,6 +22,7 @@ import { Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Typog
 import CollapsableRow from './CollapsableRow'
 import VolumesTable from './VolumesTable'
 import HostContainerTable from './HostContainerTable'
+import { useEffectOnce } from './useEffectOnce'
 
 export default function InstanceDetails (props) {
   const { instance } = props
@@ -42,7 +43,7 @@ export default function InstanceDetails (props) {
     setNetworkDetails(tmpnetworkDetails)
   }
 
-  React.useEffect(() => {
+  useEffectOnce(() => {
     if (!loadingDetails) {
       fetchDetails()
     }

--- a/src/components/InstanceDevicesConfig.js
+++ b/src/components/InstanceDevicesConfig.js
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Mon May 30 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Alert, AlertTitle, Box, Switch, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material'
+
+export default function InstanceDevicesConfig (props) {
+  const { instanceConfig, setDevicesConfig, setConfigChanged, saveConfig } = props
+
+  const handleChange = (event) => {
+    setDevicesConfig(prevState => ({
+      ...prevState,
+      devices: prevState.devices.map(
+        device => device.name === event.target.name ? { ...device, active: event.target.checked } : device
+      )
+    }))
+    // save config to activate the network adapter and receive recommendations for ip and subnetmask
+    if (event.target.checked) {
+      saveConfig(true)
+    }
+    setConfigChanged(true)
+  }
+
+  return (
+      <Box>
+          <Table>
+              <TableHead>
+                <TableRow>
+                    <TableCell colSpan={5}>
+                        <Typography variant='h6'>
+                            Devices
+                        </Typography>
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                    <TableCell colSpan={5}>
+                        <Alert sx={{ mb: 2 }} severity='info'>
+                            <AlertTitle>Info</AlertTitle>
+                            <Typography variant='body2'>Here you can activate the access to devices of your controller for the app.</Typography>
+                            <Typography variant='body2'>This means that the app can then access USB devices, CAN interfaces, or other hardware devices.</Typography>
+                            <Typography variant='body2'>A common use case is giving an app access to a license dongle.</Typography>
+                        </Alert>
+                    </TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell>Name</TableCell>
+                  <TableCell>Identifier</TableCell>
+                  <TableCell>Activate in app</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                  {instanceConfig?.devices?.map((row) => (
+                      <TableRow key={row?.name}>
+                          <TableCell>
+                            {row?.name}
+                          </TableCell>
+                          <TableCell>
+                            {row?.identifier}
+                          </TableCell>
+                          <TableCell>
+                              <Switch aria-label={row?.name + '-switch'} checked={row?.active} onChange={handleChange} name={row?.name}>
+                              </Switch>
+                          </TableCell>
+                      </TableRow>
+                  ))}
+              </TableBody>
+          </Table>
+      </Box>
+  )
+}
+
+InstanceDevicesConfig.propTypes = {
+  instanceConfig: PropTypes.object,
+  setDevicesConfig: PropTypes.func,
+  setConfigChanged: PropTypes.func,
+  saveConfig: PropTypes.func
+}

--- a/src/components/InstanceDevicesConfig.js
+++ b/src/components/InstanceDevicesConfig.js
@@ -64,6 +64,9 @@ export default function InstanceDevicesConfig (props) {
                 </TableRow>
               </TableHead>
               <TableBody>
+                <TableRow key='next-version' colSpan={3}>
+                  <Typography variant='body2' align='center'>Work in progress... stay curious for our next version 😉</Typography>
+                </TableRow>
                   {instanceConfig?.devices?.map((row) => (
                       <TableRow key={row?.name}>
                           <TableCell>

--- a/src/components/InstanceLog.js
+++ b/src/components/InstanceLog.js
@@ -21,6 +21,7 @@ import { Editor, EditorState, ContentState, Modifier } from 'draft-js'
 import { getInstanceLog, getLog } from '../api/InstanceLogService'
 import { Box, Button } from '@mui/material'
 import RefreshIcon from '@mui/icons-material/Refresh'
+import { useEffectOnce } from './useEffectOnce'
 export default function InstanceLog (props) {
   const { instance } = props
   const [loadingLog, setLoadingLog] = React.useState(false)
@@ -30,7 +31,7 @@ export default function InstanceLog (props) {
     () => EditorState.createWithContent(content)
   )
 
-  React.useEffect(() => {
+  useEffectOnce(() => {
     if (!loadingLog) {
       fetchLog()
     }

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -1,5 +1,3 @@
-import React, { useContext, useEffect } from 'react'
-
 /*
  * Copyright (c) 2021 FLECS Technologies GmbH
  *
@@ -18,17 +16,18 @@ import React, { useContext, useEffect } from 'react'
  * limitations under the License.
  */
 import PropTypes from 'prop-types'
-
+import React, { useContext } from 'react'
 import CssBaseline from '@mui/material/CssBaseline'
 import { ThemeProvider } from '@mui/material/styles'
 import { darkTheme, lightTheme } from './Theme'
 import { darkModeContext } from './ThemeHandler'
+import { useEffectOnce } from './useEffectOnce'
 
 const Layout = ({ children }) => {
   const DarkModeContext = useContext(darkModeContext)
   const { darkMode, setDarkMode } = DarkModeContext
 
-  useEffect(() => {
+  useEffectOnce(() => {
     const theme = localStorage.getItem('preferred-theme')
     if (theme) {
       const themePreference = localStorage.getItem('preferred-theme')

--- a/src/components/MarketplaceList.js
+++ b/src/components/MarketplaceList.js
@@ -28,6 +28,7 @@ import { CircularProgress, Collapse, Typography } from '@mui/material'
 import { AppFilter } from './AppFilter'
 import useStateWithLocalStorage from './LocalStorage'
 import { ReferenceDataContext } from '../data/ReferenceDataContext'
+import { useEffectOnce } from './useEffectOnce'
 
 export default function MarketplaceList (props) {
   const [products, setProducts] = useState()
@@ -128,11 +129,11 @@ export default function MarketplaceList (props) {
     }
   }
 
-  React.useEffect(() => {
+  useEffectOnce(() => {
     loadProducts()
   }, [loadProducts])
 
-  React.useEffect(() => {
+  useEffectOnce(() => {
     if (!loading) {
       updateProductCards()
     }

--- a/src/components/SelectTicket.js
+++ b/src/components/SelectTicket.js
@@ -26,6 +26,7 @@ import { MarketplaceAPIConfiguration } from '../api/api-config'
 import { addToCart } from '../api/Cart'
 import ActionSnackbar from './ActionSnackbar'
 import { getCurrentUserLicenses } from '../api/LicenseService'
+import { useEffectOnce } from './useEffectOnce'
 
 export default function SelectTicket (props) {
   const { app, tickets, setTickets } = (props)
@@ -63,7 +64,7 @@ export default function SelectTicket (props) {
       })
   }
 
-  React.useEffect(() => {
+  useEffectOnce(() => {
     if (!loadingTickets) {
       fetchTickets()
     }

--- a/src/components/Version.js
+++ b/src/components/Version.js
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Wed Jun 01 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react'
+import { Box, LinearProgress, Typography } from '@mui/material'
+import { useEffectOnce } from './useEffectOnce'
+import VersionsTable from './VersionsTable'
+import { getVersion } from '../api/VersionService'
+
+export default function Version () {
+  const [loadingVersion, setLoadingVersion] = React.useState(false)
+  const [version, setVersion] = React.useState()
+  const [error, setError] = React.useState(false)
+  const [errorText, setErrorText] = React.useState()
+
+  useEffectOnce(() => {
+    if (!loadingVersion) {
+      fetchVersion()
+    }
+  }, [])
+
+  const fetchVersion = async (props) => {
+    setLoadingVersion(true)
+
+    getVersion()
+      .then((response) => {
+        if (response) {
+          setVersion(response)
+        }
+        setError(false)
+      })
+      .catch((error) => {
+        setErrorText(error.message)
+        setError(true)
+      })
+      .finally(() => {
+        setLoadingVersion(false)
+      })
+  }
+
+  return (
+    <Box>
+        <Box alignContent='center'>
+            {(error && !loadingVersion) && <Typography align='center'>Oops... {errorText}</Typography>}
+            {loadingVersion && <LinearProgress color="primary"/>}
+            {loadingVersion && <Typography align='center'>Loading configuration...</Typography>}
+        </Box>
+        <VersionsTable coreVersion={version} webappVersion={process.env.REACT_APP_VERSION}></VersionsTable>
+    </Box>
+  )
+}

--- a/src/components/VersionsTable.js
+++ b/src/components/VersionsTable.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Thu Apr 07 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react'
+import PropTypes from 'prop-types'
+import { Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material'
+
+export default function VersionsTable (props) {
+  const { coreVersion, webappVersion } = props
+  const versions = []
+
+  function createData (component, version) {
+    return { component, version }
+  }
+
+  versions.push(createData('Core', coreVersion?.core))
+  versions.push(createData('UI', webappVersion))
+
+  return (
+        <Table data-testid="versions-table" size="small" aria-label="versions-table">
+            <TableHead>
+                <TableRow>
+                    <TableCell colSpan={2}>
+                        <Typography variant='h6'>
+                            Versions
+                        </Typography>
+                    </TableCell>
+                </TableRow>
+            </TableHead>
+            <TableBody>
+                {versions && versions?.map((component) => (
+                    <TableRow key={component.component} style={{ borderBottom: 'none' }}>
+                        <TableCell style={{ borderBottom: 'none' }}>
+                            {component.component}
+                        </TableCell>
+                        <TableCell style={{ borderBottom: 'none' }}>
+                            {component.version}
+                        </TableCell>
+                    </TableRow>
+                ))}
+            </TableBody>
+        </Table>
+  )
+}
+
+VersionsTable.propTypes = {
+  coreVersion: PropTypes.string,
+  webappVersion: PropTypes.string
+}

--- a/src/components/__tests__/InstallApp.test.js
+++ b/src/components/__tests__/InstallApp.test.js
@@ -71,7 +71,6 @@ describe('Test Install App', () => {
 
     expect(spyInstall).toHaveBeenCalled()
 
-    await screen.findByText('Installing...')
     await screen.findByText('Oops... Error during the installation of ' + app.title + '.')
 
     const icon = getByTestId('error-icon')
@@ -80,7 +79,6 @@ describe('Test Install App', () => {
     const retry = screen.getByRole('button', { name: 'Retry' })
     fireEvent.click(retry)
 
-    await screen.findByText('Installing...')
     await screen.findByText('Oops... Error during the installation of ' + app.title + '.')
   })
 })

--- a/src/components/__tests__/InstanceConfig.test.js
+++ b/src/components/__tests__/InstanceConfig.test.js
@@ -35,7 +35,9 @@ describe('InstanceConfig', () => {
     await act(async () => {
       render(<InstanceConfig instance={testInstance}></InstanceConfig>)
     })
-    expect(screen.getByText('Network interfaces')).toBeVisible()
+    expect(screen.getByText('Network')).toBeVisible()
+    expect(screen.getByText('Devices')).toBeVisible()
+    expect(screen.getByText('Here you can activate the access to the network interfaces of your controller for the app.')).toBeVisible()
   })
 
   test('Click on save-button', async () => {
@@ -44,9 +46,12 @@ describe('InstanceConfig', () => {
     })
     expect(screen.getByText('Network interfaces')).toBeVisible()
 
-    const saveButton = screen.getByTestId('save-button')
+    const saveButton = screen.getByText('Save')
 
     await act(async () => { fireEvent.click(saveButton) })
+
+    expect(screen.getByText('Save')).toBeDisabled()
+    expect(screen.getByText('Discard changes')).toBeDisabled()
   })
 
   test('Click on discard-button', async () => {
@@ -55,9 +60,25 @@ describe('InstanceConfig', () => {
     })
     expect(screen.getByText('Network interfaces')).toBeVisible()
 
-    const discardButton = screen.getByTestId('discard-button')
+    const discardButton = screen.getByText('Discard changes')
 
     await act(async () => { fireEvent.click(discardButton) })
+
+    expect(screen.getByText('Save')).toBeDisabled()
+    expect(screen.getByText('Discard changes')).toBeDisabled()
+  })
+
+  test('Click on devices', async () => {
+    await act(async () => {
+      render(<InstanceConfig instance={testInstance}></InstanceConfig>)
+    })
+    expect(screen.getByText('Network interfaces')).toBeVisible()
+
+    const devicesTab = screen.getByText('Devices')
+
+    await act(async () => { fireEvent.click(devicesTab) })
+
+    expect(screen.getByText('Here you can activate the access to devices of your controller for the app.')).toBeVisible()
   })
 
   test('Fail to load config', async () => {

--- a/src/components/__tests__/InstanceDevicesConfig.test.js
+++ b/src/components/__tests__/InstanceDevicesConfig.test.js
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Tue May 31 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react'
+import '@testing-library/jest-dom'
+import { act } from 'react-dom/test-utils'
+import { render, screen } from '@testing-library/react'
+import InstanceDevicesConfig from '../InstanceDevicesConfig'
+
+const testConfig = {
+  instanceId: 12345,
+  devices: [{}]
+}
+
+describe('InstanceDevicesConfig', () => {
+  test('renders InstanceDevicesConfig component', async () => {
+    await act(async () => {
+      render(<InstanceDevicesConfig instanceConfig={testConfig} setNicConfig={jest.fn()}></InstanceDevicesConfig>)
+    })
+
+    expect(screen.getByText('Devices')).toBeVisible()
+  })
+})

--- a/src/components/__tests__/Version.test.js
+++ b/src/components/__tests__/Version.test.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Wed Jun 01 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react'
+import '@testing-library/jest-dom'
+import { act } from 'react-dom/test-utils'
+import { render, screen } from '@testing-library/react'
+import Version from '../Version'
+jest.mock('../../api/VersionService')
+describe('Version', () => {
+  test('renders Version component', async () => {
+    await act(async () => {
+      render(<Version></Version>)
+    })
+    expect(screen.getByText('Versions')).toBeVisible()
+    expect(screen.getByText('Core')).toBeVisible()
+    expect(screen.getByText('UI')).toBeVisible()
+  })
+})

--- a/src/components/__tests__/VersionsTable.test.js
+++ b/src/components/__tests__/VersionsTable.test.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Wed Jun 01 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react'
+import '@testing-library/jest-dom'
+import { act } from 'react-dom/test-utils'
+import { render, screen } from '@testing-library/react'
+import VersionsTable from '../VersionsTable'
+
+const mockCoreVersion = {
+  core: '1.2.0-porpoise-ABCDE'
+}
+describe('VersionsTable', () => {
+  test('renders VersionsTable component', async () => {
+    await act(async () => {
+      render(<VersionsTable coreVersion={mockCoreVersion} webappVersion={'1.2.0-porpoise'}></VersionsTable>)
+    })
+    expect(screen.getByText('Versions')).toBeVisible()
+    expect(screen.getByText('Core')).toBeVisible()
+    expect(screen.getByText('UI')).toBeVisible()
+    expect(screen.getByText('1.2.0-porpoise')).toBeVisible()
+    expect(screen.getByText('1.2.0-porpoise-ABCDE')).toBeVisible()
+  })
+})

--- a/src/components/useEffectOnce.js
+++ b/src/components/useEffectOnce.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022 FLECS Technologies GmbH
+ *
+ * Created on Wed Jun 01 2022
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import React from 'react'
+// This component is a workaround for React 18 where the "normal" useEffect is called twice for useEffects with zero dependencies see more details here: https://dev.to/ag-grid/react-18-avoiding-use-effect-getting-called-twice-4i9e
+export const useEffectOnce = (effect) => {
+  const destroyFunc = React.useRef()
+  const effectCalled = React.useRef(false)
+  const renderAfterCalled = React.useRef(false)
+  const [val, setVal] = React.useState(0)
+
+  if (effectCalled.current) {
+    renderAfterCalled.current = true
+  }
+
+  React.useEffect(() => {
+    // only execute the effect first time around
+    if (!effectCalled.current) {
+      destroyFunc.current = effect()
+      effectCalled.current = true
+    }
+
+    // this forces one render after the effect is run
+    setVal(val => val + 1)
+    console.log(val)
+
+    return () => {
+      // if the comp didn't render since the useEffect was called,
+      // we know it's the dummy React cycle
+      if (!renderAfterCalled.current) { return }
+      if (destroyFunc.current) { destroyFunc.current() }
+    }
+  }, [])
+}

--- a/src/data/AppList.js
+++ b/src/data/AppList.js
@@ -19,10 +19,8 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { ReferenceDataContext } from './ReferenceDataContext'
-// import { marketPlaceAppsList } from './MarketplaceAppsList'
 import DeviceAPI from '../api/DeviceAPI'
-import { getAppIcon, getAuthor, getCustomLinks, getEditorAddress, getMultiInstance, getProducts, getReverseDomainName } from '../api/ProductService'
-// import { useSystemContext } from './SystemProvider'
+import { getAppIcon, getAuthor, getCustomLinks, getProducts, getReverseDomainName } from '../api/ProductService'
 
 class AppList extends Component {
   constructor (props) {
@@ -87,8 +85,6 @@ class AppList extends Component {
             app.title = mpApp?.name
             app.author = getAuthor(mpApp)
             app.relatedLinks = getCustomLinks(mpApp)
-            app.editor = getEditorAddress(mpApp)
-            app.multiInstance = getMultiInstance(mpApp)
           }
         })
 

--- a/src/data/SystemData.js
+++ b/src/data/SystemData.js
@@ -19,10 +19,11 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { useSystemContext } from './SystemProvider'
 import { SystemPing } from '../api/SystemPingService'
+import { useEffectOnce } from '../components/useEffectOnce'
 function SystemData (props) {
   const { setPing, loading, setLoading } = useSystemContext()
 
-  React.useEffect(() => {
+  useEffectOnce(() => {
     if (!loading) {
       fetchPing()
     }

--- a/src/pages/ServiceMesh.js
+++ b/src/pages/ServiceMesh.js
@@ -23,6 +23,7 @@ import RefreshIcon from '@mui/icons-material/Refresh'
 import ReportIcon from '@mui/icons-material/Report'
 import DeviceAPI from '../api/DeviceAPI'
 import DataTable from '../components/DataTable'
+import { useEffectOnce } from '../components/useEffectOnce'
 
 const Header = styled.div`
   display: 'flex';
@@ -52,7 +53,7 @@ export default function ServiceMesh () {
     }
     setLoading(false)
   }
-  React.useEffect(() => {
+  useEffectOnce(() => {
     if (!loading) {
       browseServiceMesh()
     }

--- a/src/pages/System.js
+++ b/src/pages/System.js
@@ -20,6 +20,7 @@ import React from 'react'
 import styled from 'styled-components'
 import { BottomNavigation, Box, Divider, Paper, Toolbar, Typography } from '@mui/material'
 import { Link } from 'react-router-dom'
+import Version from '../components/Version'
 
 const Header = styled.div`
   display: 'flex';
@@ -49,11 +50,10 @@ const System = () => {
         width: '100%',
         p: { xs: 1, sm: 2 }
       }} >
-        <Typography
-          variant='body'
-        >
-          You are currently running FLECS on {window.location.hostname} in Version {process.env.REACT_APP_VERSION}.
+        <Typography variant='body' >
+            You are currently running FLECS on {window.location.hostname}.
         </Typography>
+        <Version></Version>
       </Box>
     </Paper>
   )


### PR DESCRIPTION
- Enable app instances to access devices such as usb
- Load app information such as the available editor from device instead of marketplace
- Show the core version at the system page