### PR TITLE
Changes related to the build setup on linux

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,5 @@
-REACT_APP_DEV_VM_IP=http://flecs-dev-vm
+REACT_APP_DEV_VM_IP=http://localhost
+#TODO: rename variable? Not using Dev-VM in this setup...
 REACT_APP_DEV_MP_URL=https://mp-dev.flecs.tech
-REACT_APP_DEV_LOCAL_MP_URL=http://localhost:8000
+REACT_APP_DEV_LOCAL_MP_URL=http://localhost:8001
 REACT_APP_ENVIRONMENT=development

--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,4 @@
-REACT_APP_DEV_VM_IP=http://localhost
-#TODO: rename variable? Not using Dev-VM in this setup...
+REACT_APP_DEV_CORE_URL=http://localhost
 REACT_APP_DEV_MP_URL=https://mp-dev.flecs.tech
 REACT_APP_DEV_LOCAL_MP_URL=http://localhost:8001
 REACT_APP_ENVIRONMENT=development

--- a/src/api/api-config.js
+++ b/src/api/api-config.js
@@ -81,7 +81,7 @@ class DeviceAPIConfiguration extends Component {
   static get TARGET () {
     let target = ''
     if (process.env.REACT_APP_ENVIRONMENT === 'development') {
-      target = process.env.REACT_APP_DEV_VM_IP
+      target = process.env.REACT_APP_DEV_CORE_URL
     }
     return target
   }

--- a/src/api/api-config.js
+++ b/src/api/api-config.js
@@ -61,7 +61,7 @@ const MP_BETA_BASE_URL = 'https://mp-dev.flecs.tech'
 const MP_CART_ROUTE = '/cart?cocart-load-cart='
 const MP_BASE_DEV_URL = 'https://marketplace.flecs.tech:3000'
 
-const MP_PROXY_DEV = 'http://localhost:8000'
+const MP_PROXY_DEV = 'http://localhost:8001'
 const MP_PROXY_TEST = 'https://marketplace.flecs.tech:8443'
 const MP_PROXY_PRODUCTION = 'https://marketplace.flecs.tech'
 

--- a/src/api/device/BaseAPI.js
+++ b/src/api/device/BaseAPI.js
@@ -35,7 +35,7 @@ export default class BaseAPI extends React.Component {
       let url
       let data
       if (process.env.REACT_APP_ENVIRONMENT === 'development') {
-        url = process.env.REACT_APP_DEV_VM_IP + DeviceAPIConfiguration.DEVICE_ROUTE + apiURL
+        url = process.env.REACT_APP_DEV_CORE_URL + DeviceAPIConfiguration.DEVICE_ROUTE + apiURL
       } else {
         url = DeviceAPIConfiguration.DEVICE_ROUTE + apiURL
       }

--- a/src/api/device/DeviceAuthAPI.js
+++ b/src/api/device/DeviceAuthAPI.js
@@ -25,7 +25,7 @@ async function postMPLogin (currentUser) {
     const token = currentUser?.jwt?.token
 
     if (process.env.REACT_APP_ENVIRONMENT === 'development') {
-      url = process.env.REACT_APP_DEV_VM_IP
+      url = process.env.REACT_APP_DEV_CORE_URL
     }
     url = url + DeviceAPIConfiguration.DEVICE_ROUTE + DeviceAPIConfiguration.MARKETPLACE_ROUTE + DeviceAPIConfiguration.POST_MP_LOGIN_URL
     return axios
@@ -47,7 +47,7 @@ async function postMPLogout (currentUser) {
       const user = currentUser?.user?.data?.user_login
 
       if (process.env.REACT_APP_ENVIRONMENT === 'development') {
-        url = process.env.REACT_APP_DEV_VM_IP
+        url = process.env.REACT_APP_DEV_CORE_URL
       }
       url = url + DeviceAPIConfiguration.DEVICE_ROUTE + DeviceAPIConfiguration.MARKETPLACE_ROUTE + DeviceAPIConfiguration.POST_MP_LOGOUT_URL
       return axios

--- a/src/components/InstalledAppsList.js
+++ b/src/components/InstalledAppsList.js
@@ -190,7 +190,7 @@ export default function DeviceAppsList (props) {
 
   if (props.appData) {
     // filter on only installed apps
-    tmpAppList = props.appData.filter(app => app.status === 'installed')
+    tmpAppList = props.appData.filter(app => app?.status === 'installed')
     numberOfInstalledApps = tmpAppList.length
     tmpAppList = stableSort(tmpAppList, getComparator(order, orderBy))
       .slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)

--- a/src/components/InstalledAppsListRow.js
+++ b/src/components/InstalledAppsListRow.js
@@ -143,7 +143,7 @@ export default function Row (props) {
     let editorURL = 'http://'
 
     if (process.env.REACT_APP_ENVIRONMENT === 'development') {
-      editorURL = process.env.REACT_APP_DEV_VM_IP
+      editorURL = process.env.REACT_APP_DEV_CORE_URL
     } else {
       editorURL = editorURL + window.location.hostname
     }


### PR DESCRIPTION
When running flecs-core natively, we don't have to use flecs-dev-vm. Thus, I changed the corresponding URL in .env.development. The variable is still named REACT_APP_DEV_VM_IP though, which is no longer a very accurate description.

Since a native installation of flecs-core uses port 8000 already, we use 8001 instead.

On Linux machines, we get an error in  InstalledAppsList.js:193: 'Uncaught TypeError: app is undefined'. 
Why props.appData differs between browsers on Linux and Windows machines is unclear, but this change fixes the error.