### PR TITLE
Fix port binding in startup script

### DIFF
--- a/pkg/fs/opt/flecs-webapp/bin/flecs-webapp.sh
+++ b/pkg/fs/opt/flecs-webapp/bin/flecs-webapp.sh
@@ -103,7 +103,7 @@ case ${1} in
     PORTS=(80 8080 8000 none)
     PORTS_HEX=(0050 1F90 1F40 none)
     for i in ${!PORTS_HEX[*]}; do
-      if ! cat /proc/net/tcp /proc/net/tcp6 | grep -E ":${PORTS_HEX[$i]} [0-9A-F]{8}"; then
+      if ! cat /proc/net/tcp /proc/net/tcp6 | grep -E ":${PORTS_HEX[$i]} [0-9A-F]{8}:[0-9A-F]{4} 0A"; then
         break
       fi
     done


### PR DESCRIPTION
Consider host ports only unavailable when there is a listening socket (0A). Active connections in TCP_TIME_WAIT (06) are ignored.