### PR TITLE
test: stabilize jsdom test environment

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,6 +3,17 @@ import { afterAll, afterEach, beforeAll } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import { server } from './msw-setup';
 
+// jsdom doesn't implement Blob/File.text() — polyfill via FileReader so code
+// reading dropped or selected files works in tests.
+Blob.prototype.text ??= function (this: Blob) {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsText(this);
+  });
+};
+
 // jsdom doesn't implement <dialog> methods — stub them so components using
 // dialog.showModal()/close() (e.g. ConfirmDialog) don't crash in tests.
 HTMLDialogElement.prototype.showModal ??= function (this: HTMLDialogElement) {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,6 +3,15 @@ import { afterAll, afterEach, beforeAll } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import { server } from './msw-setup';
 
+// jsdom doesn't implement <dialog> methods — stub them so components using
+// dialog.showModal()/close() (e.g. ConfirmDialog) don't crash in tests.
+HTMLDialogElement.prototype.showModal ??= function (this: HTMLDialogElement) {
+  this.open = true;
+};
+HTMLDialogElement.prototype.close ??= function (this: HTMLDialogElement) {
+  this.open = false;
+};
+
 // Start MSW server before all tests — generated mocks from OpenAPI specs
 beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
 afterEach(() => {


### PR DESCRIPTION
Polyfills two jsdom gaps that break component tests:

- `<dialog>` methods (`showModal`/`close`) — fixes the flaky `InstalledApps` test that failed ~4/5 runs whenever random MSW mock data mounted `ConfirmDialog` (jsdom/jsdom#3294)
- `Blob.text()` via `FileReader` — required by code reading dropped/selected files (jsdom/jsdom#2555)

**Merge first** — this unflakes CI for all other open PRs.