### PR TITLE
fix: point make build targets at existing npm scripts

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -31,5 +31,5 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
-      - run: npm run build:test --if-present
+      - run: npm run build
       - run: npm test

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,11 @@ ci:
 
 .PHONY: dev-build
 dev-build: ci
-	@npm run build:test --if-present
+	@npm run build:dev
 
 .PHONY: build
 build: ci
-	@npm run build:production --if-present
+	@npm run build
 
 special_%:
 	@./special/$*.sh

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "dev:staging": "vite --mode staging",
     "prebuild": "npm run generate",
     "build": "vite build",
+    "build:dev": "vite build --mode development",
     "build:staging": "vite build --mode staging",
     "preview": "vite preview",
     "pretest": "npm run generate",


### PR DESCRIPTION
Aligns Makefile targets and the CI build step with the npm scripts that actually exist (`npm run build` instead of the removed `build:test`).