### PR TITLE
ci: enforce lint and prettier checks on push and pr

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -29,5 +29,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - run: npm ci
+      - run: npm run lint
+      - run: npm run format:check
       - run: npm run build:test --if-present
       - run: npm test


### PR DESCRIPTION
Adds `npm run lint` and `npm run format:check` to the Node.js CI workflow so style violations fail the build instead of landing on main.