### PR TITLE
feat: show editors of running apps in sidebar

### DIFF
--- a/src/app/layout/Drawer.test.tsx
+++ b/src/app/layout/Drawer.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Drawer — Editors section integration test.
+ * MSW overrides GET /apps + GET /instances with concrete data; the section
+ * must list editors of running instances and hide itself otherwise.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { renderWithProviders } from '@test/test-utils';
+import { server } from '@test/msw-setup';
+import { ThemeHandler } from '@app/theme/ThemeHandler';
+
+vi.mock('@features/auth/AuthProvider', () => ({
+  useOAuth4WebApiAuth: () => ({
+    isAuthenticated: true,
+    isLoading: false,
+    user: { sub: 'test', access_token: 'test-token' },
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+    isConfigReady: true,
+    handleOAuthCallback: vi.fn(),
+    clearError: vi.fn(),
+    refreshAuthState: vi.fn(),
+    error: null,
+  }),
+}));
+
+import Drawer from './Drawer';
+
+// jsdom has no matchMedia — stub for the mobile breakpoint + theme listeners
+beforeEach(() => {
+  window.matchMedia = (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  });
+});
+
+const APPS = [
+  {
+    appKey: { name: 'tech.flecs.node-red', version: '1.0.0' },
+    status: 'installed',
+  },
+];
+
+const RUNNING_INSTANCE = {
+  instanceId: 'abc123',
+  instanceName: 'Instance 1',
+  appKey: { name: 'tech.flecs.node-red', version: '1.0.0' },
+  status: 'running',
+  desired: 'running',
+  editors: [{ name: 'Flow Editor', port: 1880, url: '/v2/instances/abc123/editor/1880' }],
+};
+
+function mockDevice(instances: unknown[]) {
+  server.use(
+    http.get('*/apps', () => HttpResponse.json(APPS)),
+    http.get('*/instances', () => HttpResponse.json(instances)),
+  );
+}
+
+function renderDrawer() {
+  return renderWithProviders(
+    <ThemeHandler>
+      <Drawer />
+    </ThemeHandler>,
+  );
+}
+
+describe('Drawer editors section', () => {
+  it('lists editors of running instances and opens them in a new tab', async () => {
+    mockDevice([RUNNING_INSTANCE]);
+    const openSpy = vi.spyOn(window, 'open').mockImplementation(() => null);
+    renderDrawer();
+
+    await waitFor(() => expect(screen.getByText('Editors')).toBeInTheDocument());
+    // Manifest editor name is the row label
+    const row = screen.getByText('Flow Editor');
+
+    await userEvent.click(row);
+    expect(openSpy).toHaveBeenCalledWith(
+      expect.stringContaining('/api/v2/instances/abc123/editor/1880'),
+    );
+    openSpy.mockRestore();
+  });
+
+  it('hides the section when no instance is running', async () => {
+    mockDevice([{ ...RUNNING_INSTANCE, status: 'stopped' }]);
+    renderDrawer();
+
+    // Wait until data has rendered (installed badge appears), then assert no section
+    await waitFor(() => expect(screen.getByText('Installed')).toBeInTheDocument());
+    await waitFor(() => expect(screen.queryByText('Editors')).not.toBeInTheDocument());
+  });
+});

--- a/src/app/layout/Drawer.tsx
+++ b/src/app/layout/Drawer.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, Fragment } from 'react';
 import {
   Search,
   Download,
@@ -11,11 +11,14 @@ import {
   Moon,
   PanelLeftClose,
   ChevronDown,
+  ExternalLink,
+  MoreHorizontal,
 } from 'lucide-react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { useUIStore } from '@stores/ui';
-import { useGetApps } from '@generated/core/apps/apps';
-import { useGetApiV2ProductsApps } from '@generated/console/products/products';
+import { useAppList } from '@features/apps/app-queries';
+import { flattenEditors } from '@features/apps/editor-nav';
+import { createUrl } from '@features/apps/components/actions/EditorButton';
 import { useOAuth4WebApiAuth } from '@features/auth/AuthProvider';
 import { useGetDeviceLicenseActivationStatus } from '@generated/core/device/device';
 import { useDarkMode } from '@app/theme/ThemeHandler';
@@ -53,6 +56,9 @@ const NAV = [
   },
 ];
 
+/** Max editor rows shown before the "All editors" overflow link */
+const MAX_EDITORS = 8;
+
 export default function Sidebar() {
   const navigate = useNavigate();
   const { pathname } = useLocation();
@@ -61,8 +67,7 @@ export default function Sidebar() {
   const toggleSidebar = useUIStore((s) => s.toggleSidebar);
   const collapsed = useUIStore((s) => s.sidebarCollapsed);
   const toggleCollapsed = useUIStore((s) => s.toggleSidebarCollapsed);
-  const { data: appsRes } = useGetApps({ query: { refetchInterval: 10_000 } });
-  const { data: mpRes } = useGetApiV2ProductsApps(undefined, { query: { staleTime: 300_000 } });
+  const { appList, products } = useAppList();
   const auth = useOAuth4WebApiAuth();
   const { data: licData } = useGetDeviceLicenseActivationStatus({ query: { staleTime: 60_000 } });
   const activated = unwrapSuccess(licData)?.isValid ?? false;
@@ -70,10 +75,9 @@ export default function Sidebar() {
   const [profileOpen, setProfileOpen] = useState(false);
   const profileRef = useRef<HTMLDivElement>(null);
 
-  const products = unwrapSuccess(mpRes)?.data?.products ?? [];
-  const installedApps = unwrapSuccess(appsRes) ?? [];
-  const installedCount = installedApps.filter((a) => a?.status === 'installed').length;
+  const installedCount = (appList ?? []).filter((a) => a?.status === 'installed').length;
   const badges: Record<string, number> = { products: products.length, installed: installedCount };
+  const editorItems = flattenEditors(appList);
 
   useEffect(() => {
     const mq = window.matchMedia('(max-width: 899px)');
@@ -137,45 +141,108 @@ export default function Sidebar() {
         {/* Navigation */}
         <nav className="flex-1 overflow-y-auto px-2 py-1">
           {NAV.map(({ section, items }) => (
-            <div key={section} className="mb-1">
-              {!isCol && (
-                <p className="px-3 pt-3 pb-1.5 text-[11px] font-medium uppercase tracking-wider text-muted">
-                  {section}
-                </p>
+            <Fragment key={section}>
+              <div className="mb-1">
+                {!isCol && (
+                  <p className="px-3 pt-3 pb-1.5 text-[11px] font-medium uppercase tracking-wider text-muted">
+                    {section}
+                  </p>
+                )}
+                {isCol && section !== NAV[0].section && <hr className="border-border mx-1 my-2" />}
+                {items.map(({ label, icon: Icon, path, badgeKey }) => {
+                  const active = pathname === path;
+                  const badge = badgeKey ? badges[badgeKey] : undefined;
+                  return (
+                    <button
+                      key={path}
+                      title={isCol ? label : undefined}
+                      onClick={() => {
+                        navigate(path);
+                        if (isMobile) toggleSidebar();
+                      }}
+                      className={`flex items-center w-full rounded-lg mb-0.5 transition-colors cursor-pointer ${isCol ? 'justify-center py-2.5 mx-auto' : 'py-2 px-3 gap-3'} ${active ? 'bg-surface-hover text-text-primary' : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'}`}
+                    >
+                      <Icon size={18} className={active ? 'text-brand' : ''} />
+                      {!isCol && (
+                        <span
+                          className={`flex-1 text-left text-[13px] ${active ? 'font-semibold' : 'font-medium'}`}
+                        >
+                          {label}
+                        </span>
+                      )}
+                      {!isCol && badge ? (
+                        <span
+                          className={`text-[11px] font-medium tabular-nums rounded-md px-1.5 py-0.5 ${active ? 'bg-brand/15 text-brand' : 'bg-surface-hover text-muted'}`}
+                        >
+                          {badge}
+                        </span>
+                      ) : null}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {/* Editors — dynamic launcher for editors of running instances.
+                  Section disappears entirely when nothing is running. */}
+              {section === 'Apps' && editorItems.length > 0 && (
+                <div className="mb-1">
+                  {!isCol && (
+                    <p className="px-3 pt-3 pb-1.5 text-[11px] font-medium uppercase tracking-wider text-muted">
+                      Editors
+                    </p>
+                  )}
+                  {isCol && <hr className="border-border mx-1 my-2" />}
+                  {editorItems.slice(0, MAX_EDITORS).map((item) => (
+                    <button
+                      key={item.key}
+                      title={isCol ? item.label : `Open ${item.label} in a new tab`}
+                      onClick={() => {
+                        window.open(createUrl(item.url));
+                        if (isMobile) toggleSidebar();
+                      }}
+                      className={`group flex items-center w-full rounded-lg mb-0.5 transition-colors cursor-pointer text-text-secondary hover:bg-surface-hover hover:text-text-primary ${isCol ? 'justify-center py-2.5 mx-auto' : 'py-2 px-3 gap-3'}`}
+                    >
+                      {item.avatar ? (
+                        <img
+                          src={item.avatar}
+                          alt=""
+                          className="w-[18px] h-[18px] rounded shrink-0 object-cover"
+                        />
+                      ) : (
+                        <span className="w-[18px] h-[18px] rounded bg-brand/15 text-brand text-[10px] font-bold flex items-center justify-center shrink-0">
+                          {item.label[0]?.toUpperCase()}
+                        </span>
+                      )}
+                      {!isCol && (
+                        <>
+                          <span className="flex-1 text-left text-[13px] font-medium truncate">
+                            {item.label}
+                          </span>
+                          <ExternalLink
+                            size={14}
+                            className="text-muted opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+                          />
+                        </>
+                      )}
+                    </button>
+                  ))}
+                  {!isCol && editorItems.length > MAX_EDITORS && (
+                    <button
+                      onClick={() => {
+                        navigate('/');
+                        if (isMobile) toggleSidebar();
+                      }}
+                      className="flex items-center w-full rounded-lg mb-0.5 py-2 px-3 gap-3 transition-colors cursor-pointer text-muted hover:bg-surface-hover hover:text-text-primary"
+                    >
+                      <MoreHorizontal size={18} />
+                      <span className="flex-1 text-left text-[13px] font-medium">
+                        All editors ({editorItems.length})
+                      </span>
+                    </button>
+                  )}
+                </div>
               )}
-              {isCol && section !== NAV[0].section && <hr className="border-border mx-1 my-2" />}
-              {items.map(({ label, icon: Icon, path, badgeKey }) => {
-                const active = pathname === path;
-                const badge = badgeKey ? badges[badgeKey] : undefined;
-                return (
-                  <button
-                    key={path}
-                    title={isCol ? label : undefined}
-                    onClick={() => {
-                      navigate(path);
-                      if (isMobile) toggleSidebar();
-                    }}
-                    className={`flex items-center w-full rounded-lg mb-0.5 transition-colors cursor-pointer ${isCol ? 'justify-center py-2.5 mx-auto' : 'py-2 px-3 gap-3'} ${active ? 'bg-surface-hover text-text-primary' : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'}`}
-                  >
-                    <Icon size={18} className={active ? 'text-brand' : ''} />
-                    {!isCol && (
-                      <span
-                        className={`flex-1 text-left text-[13px] ${active ? 'font-semibold' : 'font-medium'}`}
-                      >
-                        {label}
-                      </span>
-                    )}
-                    {!isCol && badge ? (
-                      <span
-                        className={`text-[11px] font-medium tabular-nums rounded-md px-1.5 py-0.5 ${active ? 'bg-brand/15 text-brand' : 'bg-surface-hover text-muted'}`}
-                      >
-                        {badge}
-                      </span>
-                    ) : null}
-                  </button>
-                );
-              })}
-            </div>
+            </Fragment>
           ))}
         </nav>
 

--- a/src/features/apps/editor-nav.test.ts
+++ b/src/features/apps/editor-nav.test.ts
@@ -1,0 +1,110 @@
+/**
+ * flattenEditors — unit tests for the sidebar editor derivation.
+ */
+import { describe, it, expect } from 'vitest';
+import { flattenEditors } from './editor-nav';
+import type { EnrichedApp } from './types';
+import type { AppInstance, InstanceStatus } from '@generated/core/schemas';
+
+function makeInstance(overrides: Partial<AppInstance> = {}): AppInstance {
+  return {
+    instanceId: 'abc123',
+    instanceName: 'Instance 1',
+    appKey: { name: 'tech.flecs.node-red', version: '1.0.0' },
+    status: 'running' as InstanceStatus,
+    desired: 'running' as InstanceStatus,
+    editors: [{ name: '', port: 1880, url: '/v2/instances/abc123/editor/1880' }],
+    ...overrides,
+  };
+}
+
+function makeApp(overrides: Partial<EnrichedApp> = {}): EnrichedApp {
+  return {
+    appKey: { name: 'tech.flecs.node-red', version: '1.0.0' },
+    title: 'Node-RED',
+    avatar: 'https://example.com/icon.png',
+    instances: [makeInstance()],
+    ...overrides,
+  };
+}
+
+describe('flattenEditors', () => {
+  it('returns empty for undefined or empty app list', () => {
+    expect(flattenEditors(undefined)).toEqual([]);
+    expect(flattenEditors([])).toEqual([]);
+  });
+
+  it('maps a running instance editor to a labeled nav item', () => {
+    expect(flattenEditors([makeApp()])).toEqual([
+      {
+        key: 'abc123:1880',
+        label: 'Node-RED',
+        avatar: 'https://example.com/icon.png',
+        url: '/v2/instances/abc123/editor/1880',
+      },
+    ]);
+  });
+
+  it('prefers the manifest editor name over the app title', () => {
+    const app = makeApp({
+      instances: [
+        makeInstance({
+          editors: [{ name: 'Flow Editor', port: 1880, url: '/v2/instances/abc123/editor/1880' }],
+        }),
+      ],
+    });
+    expect(flattenEditors([app])[0].label).toBe('Flow Editor');
+  });
+
+  it('excludes instances that are not running', () => {
+    const app = makeApp({
+      instances: [makeInstance({ status: 'stopped' as InstanceStatus })],
+    });
+    expect(flattenEditors([app])).toEqual([]);
+  });
+
+  it('excludes running instances without editors', () => {
+    const app = makeApp({ instances: [makeInstance({ editors: [] })] });
+    expect(flattenEditors([app])).toEqual([]);
+  });
+
+  it('falls back to appKey.name when no marketplace title exists', () => {
+    const app = makeApp({ title: undefined, avatar: undefined });
+    expect(flattenEditors([app])[0].label).toBe('tech.flecs.node-red');
+  });
+
+  it('appends instance name when an app has multiple running instances', () => {
+    const app = makeApp({
+      instances: [
+        makeInstance({ instanceId: 'aaa', instanceName: 'Line 1' }),
+        makeInstance({ instanceId: 'bbb', instanceName: 'Line 2' }),
+      ],
+    });
+    expect(flattenEditors([app]).map((e) => e.label)).toEqual([
+      'Node-RED · Line 1',
+      'Node-RED · Line 2',
+    ]);
+  });
+
+  it('distinguishes multiple editors by name, falling back to port when unnamed', () => {
+    const app = makeApp({
+      instances: [
+        makeInstance({
+          editors: [
+            { name: 'Dashboard', port: 1880, url: '/v2/instances/abc123/editor/1880' },
+            { name: '', port: 9000, url: '/v2/instances/abc123/editor/9000' },
+          ],
+        }),
+      ],
+    });
+    expect(flattenEditors([app]).map((e) => e.label)).toEqual(['Dashboard', 'Node-RED · :9000']);
+  });
+
+  it('sorts items alphabetically by label', () => {
+    const apps = [
+      makeApp({ title: 'Zebra', instances: [makeInstance({ instanceId: 'z1' })] }),
+      makeApp({ title: 'Alpha', instances: [makeInstance({ instanceId: 'a1' })] }),
+    ];
+    expect(flattenEditors(apps).map((e) => e.label)).toEqual(['Alpha', 'Zebra']);
+  });
+});

--- a/src/features/apps/editor-nav.ts
+++ b/src/features/apps/editor-nav.ts
@@ -1,0 +1,52 @@
+/**
+ * Editor navigation — derives sidebar launcher entries from the enriched app list.
+ * Pure function, no hooks: only editors of running instances are surfaced.
+ */
+import type { EnrichedApp } from '@features/apps/types';
+
+export interface EditorNavItem {
+  /** Stable key: `${instanceId}:${port}` */
+  key: string;
+  /** Editor name from the app manifest; falls back to the app title.
+   *  Disambiguated by instance name / port when needed. */
+  label: string;
+  avatar?: string;
+  url: string;
+}
+
+export function flattenEditors(appList: EnrichedApp[] | undefined): EditorNavItem[] {
+  if (!appList?.length) return [];
+
+  const entries = appList.flatMap((app) => {
+    const title = app.title ?? app.appKey.name;
+    return (app.instances ?? [])
+      .filter((i) => i.status === 'running' && (i.editors?.length ?? 0) > 0)
+      .map((instance) => ({ title, avatar: app.avatar, instance }));
+  });
+
+  // Count running instances per title so multi-instance apps get the instance name appended.
+  const instancesPerTitle = new Map<string, number>();
+  for (const { title } of entries) {
+    instancesPerTitle.set(title, (instancesPerTitle.get(title) ?? 0) + 1);
+  }
+
+  return entries
+    .flatMap(({ title, avatar, instance }) => {
+      const editors = instance.editors ?? [];
+      const multiInstance = (instancesPerTitle.get(title) ?? 0) > 1;
+      const multiEditor = editors.length > 1;
+      return editors.map((editor) => {
+        // Manifest editor name wins; unnamed editors fall back to the app title.
+        const parts = [editor.name?.trim() || title];
+        if (multiInstance) parts.push(instance.instanceName);
+        if (multiEditor && !editor.name?.trim()) parts.push(`:${editor.port}`);
+        return {
+          key: `${instance.instanceId}:${editor.port}`,
+          label: parts.join(' · '),
+          avatar,
+          url: editor.url,
+        };
+      });
+    })
+    .sort((a, b) => a.label.localeCompare(b.label));
+}


### PR DESCRIPTION
Adds a dynamic **Editors** section to the sidebar listing every editor of every running instance — one click from anywhere instead of digging through the Installed list.

- Label = manifest editor name (`InstanceEditor.name`), fallback app title; disambiguation by instance name/port
- App icon in collapsed mode; letter tile for sideloaded apps
- Section disappears when nothing is running; opens in a new tab via the existing `createUrl()`
- Drawer now uses `useAppList()` instead of two raw queries (net simplification)

Tests: 8 unit (label/filter/sort derivation) + 2 component (MSW-mocked instances).