### PR TITLE
fix: use export/import terminology for device config

### DIFF
--- a/src/features/system/components/QuickActions.tsx
+++ b/src/features/system/components/QuickActions.tsx
@@ -8,7 +8,7 @@ export default function QuickActions() {
     <div className="rounded-xl bg-dark-end p-6 border border-white/10">
       <h6 className="text-base font-semibold mb-4">Quick Actions</h6>
       <div className="flex items-center gap-4 flex-wrap">
-        <span title="Export all apps and data from this device">
+        <span title="Download apps from this device">
           <Export />
         </span>
         <span title="Import apps from a backup file">

--- a/src/features/system/components/data-transfer/Export.tsx
+++ b/src/features/system/components/data-transfer/Export.tsx
@@ -96,7 +96,7 @@ const Export: React.FC<ExportProps> = (props) => {
       ) : (
         <FolderDown size={16} />
       )}
-      {exporting ? 'Downloading...' : 'Download App Config'}
+      {exporting ? 'Exporting...' : 'Export Config'}
     </button>
   );
 };

--- a/src/features/system/components/data-transfer/Export.tsx
+++ b/src/features/system/components/data-transfer/Export.tsx
@@ -96,7 +96,7 @@ const Export: React.FC<ExportProps> = (props) => {
       ) : (
         <FolderDown size={16} />
       )}
-      {exporting ? 'Exporting...' : 'Export Config'}
+      {exporting ? 'Exporting...' : 'Export Apps'}
     </button>
   );
 };

--- a/src/features/system/components/data-transfer/Export.tsx
+++ b/src/features/system/components/data-transfer/Export.tsx
@@ -96,7 +96,7 @@ const Export: React.FC<ExportProps> = (props) => {
       ) : (
         <FolderDown size={16} />
       )}
-      {exporting ? 'Exporting...' : 'Export Apps'}
+      {exporting ? 'Downloading...' : 'Download Apps'}
     </button>
   );
 };

--- a/src/features/system/components/data-transfer/Import.tsx
+++ b/src/features/system/components/data-transfer/Import.tsx
@@ -49,7 +49,7 @@ export default function Import(props: ImportProps) {
     } else if (fileName.endsWith('.json')) {
       handleJsonFile(file);
     } else {
-      toast.error('Unsupported file type. Please upload a .tar, .tar.gz or .json file.');
+      toast.error('Unsupported file type. Please select a .tar, .tar.gz or .json file.');
     }
   };
 

--- a/src/features/system/components/data-transfer/Import.tsx
+++ b/src/features/system/components/data-transfer/Import.tsx
@@ -109,7 +109,7 @@ export default function Import(props: ImportProps) {
     <FileOpen
       {...buttonProps}
       data-testid="import-apps-button"
-      buttonText="Import Config"
+      buttonText="Import Apps"
       buttonIcon={<FolderUp size={16} />}
       accept=".tar.gz, .tar, .json"
       onConfirm={handleFileUpload}


### PR DESCRIPTION
## Summary

- **\"Export Apps\"** → **\"Download Apps\"** (busy: \"Downloading...\") — reflects the user action of downloading a local archive from the device
- **\"Import Config\"** → **\"Import Apps\"** — consistent with the Download Apps counterpart
- Import wrong-file toast: \"please upload\" → \"please select\"

Kept on purpose: \"Upload Manifest\" (sideloading is a real upload) and the download icon in the Exports list (downloading an existing archive).

## Test plan

- [ ] Quick Actions shows \"Download Apps\" button
- [ ] Busy state shows \"Downloading...\" during export
- [ ] Quick Actions shows \"Import Apps\" button
- [ ] Wrong-file toast shows \"please select\" (not \"please upload\")