### PR TITLE
feat: drag-and-drop for manifest sideload and config import

### DIFF
--- a/src/app/components/useFileDrop.test.tsx
+++ b/src/app/components/useFileDrop.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * useFileDrop — unit tests via a minimal harness element.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useFileDrop } from './useFileDrop';
+
+function Harness(props: Parameters<typeof useFileDrop>[0]) {
+  const { isDragOver, dropProps } = useFileDrop(props);
+  return (
+    <div data-testid="zone" data-dragover={isDragOver} {...dropProps}>
+      drop here
+    </div>
+  );
+}
+
+const jsonFile = new File(['{}'], 'manifest.json', { type: 'application/json' });
+const pngFile = new File(['x'], 'image.png', { type: 'image/png' });
+
+describe('useFileDrop', () => {
+  it('calls onFile for a matching extension', () => {
+    const onFile = vi.fn();
+    render(<Harness accept={['.json']} onFile={onFile} />);
+    fireEvent.drop(screen.getByTestId('zone'), { dataTransfer: { files: [jsonFile] } });
+    expect(onFile).toHaveBeenCalledWith(jsonFile);
+  });
+
+  it('calls onReject (not onFile) for a non-matching extension', () => {
+    const onFile = vi.fn();
+    const onReject = vi.fn();
+    render(<Harness accept={['.json']} onFile={onFile} onReject={onReject} />);
+    fireEvent.drop(screen.getByTestId('zone'), { dataTransfer: { files: [pngFile] } });
+    expect(onFile).not.toHaveBeenCalled();
+    expect(onReject).toHaveBeenCalledWith(pngFile);
+  });
+
+  it('accepts any file when accept is omitted', () => {
+    const onFile = vi.fn();
+    render(<Harness onFile={onFile} />);
+    fireEvent.drop(screen.getByTestId('zone'), { dataTransfer: { files: [pngFile] } });
+    expect(onFile).toHaveBeenCalledWith(pngFile);
+  });
+
+  it('matches multi-part extensions like .tar.gz', () => {
+    const onFile = vi.fn();
+    const tarGz = new File(['x'], 'backup.tar.gz');
+    render(<Harness accept={['.tar', '.tar.gz']} onFile={onFile} />);
+    fireEvent.drop(screen.getByTestId('zone'), { dataTransfer: { files: [tarGz] } });
+    expect(onFile).toHaveBeenCalledWith(tarGz);
+  });
+
+  it('tracks drag-over state across enter/leave, including nested elements', () => {
+    render(<Harness accept={['.json']} onFile={vi.fn()} />);
+    const zone = screen.getByTestId('zone');
+    expect(zone.dataset.dragover).toBe('false');
+
+    fireEvent.dragEnter(zone); // enter zone
+    fireEvent.dragEnter(zone); // enter a child
+    expect(zone.dataset.dragover).toBe('true');
+    fireEvent.dragLeave(zone); // leave the child — still inside zone
+    expect(zone.dataset.dragover).toBe('true');
+    fireEvent.dragLeave(zone); // leave zone
+    expect(zone.dataset.dragover).toBe('false');
+  });
+
+  it('resets drag-over state after a drop', () => {
+    render(<Harness accept={['.json']} onFile={vi.fn()} />);
+    const zone = screen.getByTestId('zone');
+    fireEvent.dragEnter(zone);
+    fireEvent.drop(zone, { dataTransfer: { files: [jsonFile] } });
+    expect(zone.dataset.dragover).toBe('false');
+  });
+
+  it('ignores everything when disabled', () => {
+    const onFile = vi.fn();
+    render(<Harness accept={['.json']} onFile={onFile} disabled />);
+    const zone = screen.getByTestId('zone');
+    fireEvent.dragEnter(zone);
+    expect(zone.dataset.dragover).toBe('false');
+    fireEvent.drop(zone, { dataTransfer: { files: [jsonFile] } });
+    expect(onFile).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/components/useFileDrop.ts
+++ b/src/app/components/useFileDrop.ts
@@ -1,0 +1,55 @@
+import { useState, useRef } from 'react';
+
+interface FileDropOptions {
+  /** Allowed extensions (lowercase, with dot), e.g. ['.json', '.tar.gz'].
+   *  Omit to accept any file and validate downstream. */
+  accept?: string[];
+  onFile: (file: File) => void;
+  /** Called when the dropped file doesn't match `accept`. */
+  onReject?: (file: File) => void;
+  disabled?: boolean;
+}
+
+/**
+ * Native HTML5 drag-and-drop for a single file. Spread `dropProps` on the
+ * target element and use `isDragOver` for visual feedback.
+ */
+export function useFileDrop({ accept, onFile, onReject, disabled }: FileDropOptions) {
+  const [isDragOver, setIsDragOver] = useState(false);
+  // dragenter/dragleave also fire when moving over child elements — track depth
+  const depth = useRef(0);
+
+  const matches = (name: string) =>
+    !accept || accept.some((ext) => name.toLowerCase().endsWith(ext));
+
+  const dropProps = {
+    onDragEnter: (e: React.DragEvent) => {
+      e.preventDefault();
+      if (disabled) return;
+      depth.current += 1;
+      setIsDragOver(true);
+    },
+    onDragOver: (e: React.DragEvent) => {
+      e.preventDefault();
+    },
+    onDragLeave: (e: React.DragEvent) => {
+      e.preventDefault();
+      if (disabled) return;
+      depth.current = Math.max(0, depth.current - 1);
+      if (depth.current === 0) setIsDragOver(false);
+    },
+    onDrop: (e: React.DragEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      depth.current = 0;
+      setIsDragOver(false);
+      if (disabled) return;
+      const file = e.dataTransfer?.files?.[0];
+      if (!file) return;
+      if (matches(file.name)) onFile(file);
+      else onReject?.(file);
+    },
+  };
+
+  return { isDragOver, dropProps };
+}

--- a/src/features/system/components/data-transfer/Import.test.tsx
+++ b/src/features/system/components/data-transfer/Import.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * Import — dropzone variant tests.
+ * Network + quest layers are mocked at module level; we assert the dropped
+ * file reaches the correct API call (or is rejected before any call).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '@test/test-utils';
+
+vi.mock('@features/notifications/quests/hooks', () => ({
+  useQuestActions: () => ({
+    fetchQuest: vi.fn().mockResolvedValue(undefined),
+    waitForQuest: vi.fn().mockResolvedValue({ state: 'finished', description: '' }),
+  }),
+}));
+vi.mock('@features/notifications/quests/QuestItem', () => ({
+  questStateFinishedOk: () => true,
+}));
+vi.mock('@generated/core/flecsport/flecsport', () => ({
+  postImports: vi.fn().mockResolvedValue({ status: 202, data: { jobId: 1 } }),
+}));
+vi.mock('@generated/core/device/device', () => ({
+  postDeviceOnboarding: vi.fn().mockResolvedValue({ status: 202, data: { jobId: 2 } }),
+}));
+
+import Import from './Import';
+import { postImports } from '@generated/core/flecsport/flecsport';
+import { postDeviceOnboarding } from '@generated/core/device/device';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('Import dropzone', () => {
+  it('renders as a plain button without the dropzone prop', () => {
+    renderWithProviders(<Import />);
+    expect(screen.queryByTestId('import-dropzone')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import config/i })).toBeInTheDocument();
+  });
+
+  it('imports a dropped .tar archive via the imports API', async () => {
+    renderWithProviders(<Import dropzone />);
+    const tar = new File(['x'], 'backup.tar', { type: 'application/x-tar' });
+    fireEvent.drop(screen.getByTestId('import-dropzone'), { dataTransfer: { files: [tar] } });
+    await waitFor(() => expect(postImports).toHaveBeenCalledWith({ file: tar }));
+  });
+
+  it('imports a dropped .json config via the onboarding API', async () => {
+    renderWithProviders(<Import dropzone />);
+    const json = new File(['{"apps":[]}'], 'config.json', { type: 'application/json' });
+    fireEvent.drop(screen.getByTestId('import-dropzone'), { dataTransfer: { files: [json] } });
+    await waitFor(() => expect(postDeviceOnboarding).toHaveBeenCalledWith({ apps: [] }));
+    expect(postImports).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unsupported file type without any API call', async () => {
+    renderWithProviders(<Import dropzone />);
+    const png = new File(['x'], 'image.png', { type: 'image/png' });
+    fireEvent.drop(screen.getByTestId('import-dropzone'), { dataTransfer: { files: [png] } });
+    await waitFor(() => {
+      expect(postImports).not.toHaveBeenCalled();
+      expect(postDeviceOnboarding).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/features/system/components/data-transfer/Import.tsx
+++ b/src/features/system/components/data-transfer/Import.tsx
@@ -20,6 +20,7 @@ import React from 'react';
 import { toast } from 'sonner';
 import { FolderUp } from 'lucide-react';
 import FileOpen from '@app/components/FileOpen';
+import { useFileDrop } from '@app/components/useFileDrop';
 
 import { useQuestActions } from '@features/notifications/quests/hooks';
 import { questStateFinishedOk } from '@features/notifications/quests/QuestItem';
@@ -28,10 +29,15 @@ import { postImports } from '@generated/core/flecsport/flecsport';
 import { unwrapSuccess } from '@app/api/unwrap';
 import { getErrorMessage } from '@app/api/fetch-error';
 
-export default function Import(props: React.ComponentProps<'button'>) {
+interface ImportProps extends React.ComponentProps<'button'> {
+  /** Render as a drag-and-drop zone (dashed container) instead of a bare button. */
+  dropzone?: boolean;
+}
+
+export default function Import(props: ImportProps) {
   const qc = useQueryClient();
   const { fetchQuest, waitForQuest } = useQuestActions();
-  const { ...buttonProps } = props;
+  const { dropzone, ...buttonProps } = props;
   const [importing, setImporting] = React.useState(false);
 
   const handleFileUpload = (file: string | File) => {
@@ -92,7 +98,14 @@ export default function Import(props: React.ComponentProps<'button'>) {
     }
   };
 
-  return (
+  // handleFileUpload validates the extension and toasts on mismatch,
+  // so the dropzone accepts any file and defers validation.
+  const { isDragOver, dropProps } = useFileDrop({
+    onFile: handleFileUpload,
+    disabled: buttonProps.disabled || importing,
+  });
+
+  const button = (
     <FileOpen
       {...buttonProps}
       data-testid="import-apps-button"
@@ -104,5 +117,20 @@ export default function Import(props: React.ComponentProps<'button'>) {
       wholeFile={true}
       disabled={buttonProps.disabled || importing}
     ></FileOpen>
+  );
+
+  if (!dropzone) return button;
+
+  return (
+    <div
+      data-testid="import-dropzone"
+      {...dropProps}
+      className={`px-5 rounded-xl border border-dashed flex items-center gap-4 hover:border-brand hover:bg-brand/3 transition ${isDragOver ? 'border-brand bg-brand/3' : 'border-white/10'}`}
+    >
+      <div className="w-9 h-9 rounded-lg bg-white/5 flex items-center justify-center text-muted shrink-0">
+        <FolderUp size={18} />
+      </div>
+      {button}
+    </div>
   );
 }

--- a/src/pages/InstalledApps.test.tsx
+++ b/src/pages/InstalledApps.test.tsx
@@ -21,12 +21,39 @@ vi.mock('@features/auth/AuthProvider', () => ({
 }));
 
 import InstalledApps from './InstalledApps';
+import { fireEvent } from '@testing-library/react';
 
 describe('Installed Apps', () => {
   it('renders installed apps heading', async () => {
     renderWithProviders(<InstalledApps />, { route: '/' });
     await waitFor(() => {
       expect(screen.getByText(/installed apps/i)).toBeTruthy();
+    });
+  });
+
+  it('starts the sideload stepper when a manifest is dropped on the deploy card', async () => {
+    renderWithProviders(<InstalledApps />, { route: '/' });
+    const card = await screen.findByTestId('sideload-dropzone');
+
+    const manifest = new File(['{"app":"tech.flecs.test","version":"1.0.0"}'], 'manifest.json', {
+      type: 'application/json',
+    });
+    fireEvent.drop(card, { dataTransfer: { files: [manifest] } });
+
+    await waitFor(() => {
+      expect(screen.getByText('Installing Sideloaded App')).toBeInTheDocument();
+    });
+  });
+
+  it('does not start the stepper for a non-json drop', async () => {
+    renderWithProviders(<InstalledApps />, { route: '/' });
+    const card = await screen.findByTestId('sideload-dropzone');
+
+    const png = new File(['x'], 'image.png', { type: 'image/png' });
+    fireEvent.drop(card, { dataTransfer: { files: [png] } });
+
+    await waitFor(() => {
+      expect(screen.queryByText('Installing Sideloaded App')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/pages/InstalledApps.tsx
+++ b/src/pages/InstalledApps.tsx
@@ -1,5 +1,5 @@
-import { useMemo, useRef, useState } from 'react';
-import { FileCode2, FolderUp, PackagePlus, RefreshCw } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { FileCode2, PackagePlus, RefreshCw } from 'lucide-react';
 import { toast } from 'sonner';
 import { useAppList } from '@features/apps/app-queries';
 import { useGetSystemPing } from '@generated/core/system/system';
@@ -9,6 +9,7 @@ import type { Quest } from '@generated/core/schemas';
 import EmptyApps from '@features/apps/components/EmptyApps';
 import InstalledAppsTable from '../features/apps/components/InstalledAppsTable';
 import ContentDialog from '@app/components/ContentDialog';
+import { useFileDrop } from '@app/components/useFileDrop';
 import InstallationStepper from '@features/apps/components/installation/InstallationStepper';
 import Import from '@features/system/components/data-transfer/Import';
 import Export from '@features/system/components/data-transfer/Export';
@@ -99,11 +100,7 @@ export default function InstalledApps() {
   const appsWithUpdates = getAppsWithUpdates(installedApps);
   const updateCount = appsWithUpdates.length;
 
-  const handleSideloadFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    e.target.value = '';
-    if (!file) return;
-
+  const sideloadFile = async (file: File) => {
     const MAX_BYTES = 1 * 1024 * 1024;
     if (file.size > MAX_BYTES) {
       toast.error(
@@ -127,6 +124,36 @@ export default function InstalledApps() {
       });
     }
   };
+
+  const handleSideloadFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (file) sideloadFile(file);
+  };
+
+  const rejectManifest = () =>
+    toast.error('Unsupported file type. Please drop a .json manifest file.');
+  const cardDrop = useFileDrop({
+    accept: ['.json'],
+    onFile: sideloadFile,
+    onReject: rejectManifest,
+  });
+  const dialogDrop = useFileDrop({
+    accept: ['.json'],
+    onFile: sideloadFile,
+    onReject: rejectManifest,
+  });
+
+  // A file dropped outside a dropzone must not navigate the browser away
+  useEffect(() => {
+    const prevent = (e: DragEvent) => e.preventDefault();
+    window.addEventListener('dragover', prevent);
+    window.addEventListener('drop', prevent);
+    return () => {
+      window.removeEventListener('dragover', prevent);
+      window.removeEventListener('drop', prevent);
+    };
+  }, []);
 
   if (!ping)
     return (
@@ -162,8 +189,10 @@ export default function InstalledApps() {
 
       <div className="flex gap-4 mb-5">
         <div
+          data-testid="sideload-dropzone"
           onClick={() => setSideloadPickerOpen(true)}
-          className="flex-1 px-5 py-4 rounded-xl border border-dashed border-white/10 flex items-center gap-4 cursor-pointer hover:border-brand hover:bg-brand/3 transition"
+          {...cardDrop.dropProps}
+          className={`flex-1 px-5 py-4 rounded-xl border border-dashed flex items-center gap-4 cursor-pointer hover:border-brand hover:bg-brand/3 transition ${cardDrop.isDragOver ? 'border-brand bg-brand/3' : 'border-white/10'}`}
         >
           <div className="w-11 h-11 rounded-xl bg-white/5 flex items-center justify-center text-muted shrink-0">
             <PackagePlus size={22} />
@@ -171,7 +200,7 @@ export default function InstalledApps() {
           <div className="flex-1">
             <span className="text-sm font-bold block">Deploy Your Own App</span>
             <span className="text-xs text-muted">
-              Upload a custom app manifest to sideload private Docker apps.
+              Drop a manifest here or click to sideload private Docker apps.
             </span>
           </div>
           <button
@@ -181,12 +210,7 @@ export default function InstalledApps() {
             <PackagePlus size={14} /> Upload Manifest
           </button>
         </div>
-        <div className="px-5 rounded-xl border border-dashed border-white/10 flex items-center gap-4 hover:border-brand hover:bg-brand/3 transition">
-          <div className="w-9 h-9 rounded-lg bg-white/5 flex items-center justify-center text-muted shrink-0">
-            <FolderUp size={18} />
-          </div>
-          <Import />
-        </div>
+        <Import dropzone />
       </div>
 
       {updateCount > 0 && (
@@ -235,15 +259,19 @@ export default function InstalledApps() {
             Sideload a private or custom Docker app by uploading its manifest.
           </p>
           <div
-            className="border-2 border-dashed border-white/10 rounded-xl py-10 px-6 text-center cursor-pointer hover:border-brand hover:bg-brand/3 transition"
+            data-testid="sideload-dialog-dropzone"
+            className={`border-2 border-dashed rounded-xl py-10 px-6 text-center cursor-pointer hover:border-brand hover:bg-brand/3 transition ${dialogDrop.isDragOver ? 'border-brand bg-brand/3' : 'border-white/10'}`}
             onClick={() => sideloadInputRef.current?.click()}
+            {...dialogDrop.dropProps}
           >
             <FileCode2
               size={32}
               strokeWidth={1.5}
               style={{ opacity: 0.4, marginBottom: 8, display: 'inline-block' }}
             />
-            <span className="text-sm font-bold block mb-1">Select app manifest</span>
+            <span className="text-sm font-bold block mb-1">
+              Drop your manifest here or click to browse
+            </span>
             <span className="text-xs text-muted">Accepts .json (max 1 MiB)</span>
           </div>
           <p className="text-xs text-muted mt-4">


### PR DESCRIPTION
Resolves *[Webapp] Drag-and-drop for manifest sideloading* — the dashed borders promised drop support that didn't exist.

- New `useFileDrop` hook (native HTML5 DnD, ~50 lines, zero deps) on three surfaces: Deploy-Your-Own-App card (drop skips the picker dialog), the dialog dropzone, and Import Config (`<Import dropzone />`)
- Window-level guard: a missed drop no longer navigates the browser away from the app
- Click paths, validation and toasts unchanged — drop feeds the same handlers as the file picker

Tests: 7 hook + 2 page + 4 import-variant.

> ⚠ **Stacked on #396** (needs the `Blob.text()` polyfill for its tests). Retarget to `main` after #396 merges.