### PR TITLE
fix: unescape &amp; last to prevent double HTML entity decoding

### DIFF
--- a/src/features/marketplace/components/Card.tsx
+++ b/src/features/marketplace/components/Card.tsx
@@ -47,11 +47,11 @@ export default function MarketplaceCard(props: MarketplaceCardProps) {
   const [fullCardOpen, setFullCardOpen] = useState(false);
   const plainDescription = (props.short_description || '')
     .replace(/<[^>]*>/g, '')
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
-    .replace(/&#039;/g, "'");
+    .replace(/&#039;/g, "'")
+    .replace(/&amp;/g, '&');
   const isFree = !props.price || parseFloat(props.price) === 0;
 
   return (


### PR DESCRIPTION
Potential fix for [https://github.com/FLECS-Technologies/flecs-webapp/security/code-scanning/6](https://github.com/FLECS-Technologies/flecs-webapp/security/code-scanning/6)

To fix this without changing intended functionality, keep the same manual decoding approach but decode `&amp;` **last**.  
In `src/features/marketplace/components/Card.tsx`, update the `plainDescription` replacement chain so entity-specific replacements (`&lt;`, `&gt;`, `&quot;`, `&#039;`) occur before `&amp;`.

This preserves current behavior for normal encoded text while preventing double-unescape cases like `&amp;lt;` from becoming `<` in the same pass.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
