### PR TITLE
fix: loading flicker after login and on reload

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,13 @@
     <title>FLECS</title>
     <link rel="manifest" href="/manifest.json" />
     <link rel="icon" href="/src/assets/favicon.ico" />
+    <!-- Paint dark before the CSS bundle loads — prevents white flash on reload
+         in browsers without paint holding (Safari). Matches --color-surface. -->
+    <style>
+      html {
+        background-color: #0b0b18;
+      }
+    </style>
   </head>
   <body>
     <div id="root"></div>

--- a/src/app/Providers.test.tsx
+++ b/src/app/Providers.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * AuthGate — render-order regression tests.
+ * Auth state comes synchronously from localStorage; the auth-config fetch
+ * (isLoading) must never block an already-authenticated render, otherwise a
+ * spinner flashes on every reload and after the OAuth redirect.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '@test/test-utils';
+
+const authState = {
+  isAuthenticated: false,
+  isLoading: false,
+  user: null,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  isConfigReady: true,
+  handleOAuthCallback: vi.fn(),
+  clearError: vi.fn(),
+  refreshAuthState: vi.fn(),
+  error: null,
+};
+
+vi.mock('@features/auth/AuthProvider', () => ({
+  OAuth4WebApiAuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  useOAuth4WebApiAuth: () => authState,
+}));
+
+import Providers from './Providers';
+
+describe('AuthGate', () => {
+  it('renders children immediately when authenticated, even while auth config loads', () => {
+    Object.assign(authState, { isAuthenticated: true, isLoading: true });
+    renderWithProviders(<Providers>app-content</Providers>);
+    expect(screen.getByText('app-content')).toBeTruthy();
+  });
+
+  it('shows the spinner while config loads when not authenticated', () => {
+    Object.assign(authState, { isAuthenticated: false, isLoading: true });
+    const { container } = renderWithProviders(<Providers>app-content</Providers>);
+    expect(screen.queryByText('app-content')).toBeNull();
+    expect(container.querySelector('.animate-spin')).toBeTruthy();
+  });
+
+  it('shows the device login when not authenticated and config loaded', () => {
+    Object.assign(authState, { isAuthenticated: false, isLoading: false });
+    renderWithProviders(<Providers>app-content</Providers>);
+    expect(screen.queryByText('app-content')).toBeNull();
+    expect(screen.getByText('Welcome')).toBeTruthy();
+  });
+});

--- a/src/app/Providers.tsx
+++ b/src/app/Providers.tsx
@@ -6,14 +6,17 @@ import DeviceLogin from '@pages/DeviceLogin';
 function AuthGate({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useOAuth4WebApiAuth();
   if (window.location.hash.includes('/oauth/callback')) return <>{children}</>;
+  // Auth state is known synchronously (localStorage) — render the app immediately.
+  // isLoading only tracks the auth-config fetch, which signIn needs but the app doesn't;
+  // gating on it flashed a spinner on every reload and after the OAuth redirect.
+  if (isAuthenticated) return <>{children}</>;
   if (isLoading)
     return (
       <div className="flex justify-center items-center min-h-screen">
         <div className="animate-spin h-6 w-6 border-2 border-brand border-t-transparent rounded-full" />
       </div>
     );
-  if (!isAuthenticated) return <DeviceLogin />;
-  return <>{children}</>;
+  return <DeviceLogin />;
 }
 
 export default function Providers({ children }: { children: React.ReactNode }) {

--- a/src/features/apps/components/RowSkeleton.tsx
+++ b/src/features/apps/components/RowSkeleton.tsx
@@ -1,0 +1,25 @@
+/**
+ * App-list loading skeleton — shared so the OAuth landing and the Installed Apps
+ * page show the exact same placeholder. Keeping them identical is what makes the
+ * sign-in transition read as one continuous "loading" state instead of a flicker.
+ */
+export default function RowSkeleton() {
+  return (
+    <div className="rounded-xl border border-white/10 overflow-hidden">
+      {[0, 1, 2].map((i) => (
+        <div key={i} className={i > 0 ? 'border-t border-white/10' : ''}>
+          <div className="flex items-center gap-4 px-5 py-3">
+            <div className="animate-pulse bg-white/10 rounded-lg w-12 h-12" />
+            <div className="flex-1">
+              <div className="animate-pulse bg-white/10 rounded h-5 w-[35%]" />
+              <div className="animate-pulse bg-white/10 rounded h-3.5 w-[45%] mt-1" />
+              <div className="animate-pulse bg-white/10 rounded h-3 w-[15%] mt-1" />
+            </div>
+            <div className="animate-pulse bg-white/10 rounded-lg w-[72px] h-8" />
+            <div className="animate-pulse bg-white/10 rounded-full w-7 h-7" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/InstalledApps.test.tsx
+++ b/src/pages/InstalledApps.test.tsx
@@ -31,6 +31,21 @@ describe('Installed Apps', () => {
     });
   });
 
+  it('shows the skeleton while loading, never the "not ready" flash, then the data', async () => {
+    // Regression: ping/app-list are in-flight on first render. The page must show
+    // the skeleton — not "FLECS services are not ready" — so a reload goes straight
+    // from skeleton to data with nothing flashing in between.
+    const { container } = renderWithProviders(<InstalledApps />, { route: '/' });
+
+    expect(screen.queryByText(/not ready/i)).toBeNull();
+    expect(container.querySelector('.animate-pulse')).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText(/installed apps/i)).toBeTruthy();
+    });
+    expect(screen.queryByText(/not ready/i)).toBeNull();
+  });
+
   it('starts the sideload stepper when a manifest is dropped on the deploy card', async () => {
     renderWithProviders(<InstalledApps />, { route: '/' });
     const card = await screen.findByTestId('sideload-dropzone');

--- a/src/pages/InstalledApps.tsx
+++ b/src/pages/InstalledApps.tsx
@@ -8,6 +8,7 @@ import { QuestState } from '@generated/core/schemas';
 import type { Quest } from '@generated/core/schemas';
 import EmptyApps from '@features/apps/components/EmptyApps';
 import InstalledAppsTable from '../features/apps/components/InstalledAppsTable';
+import RowSkeleton from '@features/apps/components/RowSkeleton';
 import ContentDialog from '@app/components/ContentDialog';
 import { useFileDrop } from '@app/components/useFileDrop';
 import InstallationStepper from '@features/apps/components/installation/InstallationStepper';
@@ -17,27 +18,6 @@ import type { EnrichedApp, AppVersion } from '@features/apps/types';
 import { unwrapSuccess } from '@app/api/unwrap';
 const getLatestVersion = (versions: AppVersion[]) => versions?.[0];
 const createVersions = (v: AppVersion[], _installed?: string[]) => v;
-
-function RowSkeleton() {
-  return (
-    <div className="rounded-xl border border-white/10 overflow-hidden">
-      {[0, 1, 2].map((i) => (
-        <div key={i} className={i > 0 ? 'border-t border-white/10' : ''}>
-          <div className="flex items-center gap-4 px-5 py-3">
-            <div className="animate-pulse bg-white/10 rounded-lg w-12 h-12" />
-            <div className="flex-1">
-              <div className="animate-pulse bg-white/10 rounded h-5 w-[35%]" />
-              <div className="animate-pulse bg-white/10 rounded h-3.5 w-[45%] mt-1" />
-              <div className="animate-pulse bg-white/10 rounded h-3 w-[15%] mt-1" />
-            </div>
-            <div className="animate-pulse bg-white/10 rounded-lg w-[72px] h-8" />
-            <div className="animate-pulse bg-white/10 rounded-full w-7 h-7" />
-          </div>
-        </div>
-      ))}
-    </div>
-  );
-}
 
 function getAppsWithUpdates(apps: EnrichedApp[]) {
   return apps.filter((app) => {
@@ -56,12 +36,15 @@ function parseInstallQuest(desc: string) {
 
 export default function InstalledApps() {
   const { appList, isLoading: appListLoading, isError: appListError } = useAppList();
-  const { data: pingData } = useGetSystemPing({ query: { retry: false, refetchInterval: 30_000 } });
+  const { data: pingData, isLoading: pingLoading } = useGetSystemPing({
+    query: { retry: false, refetchInterval: 30_000 },
+  });
   // Read from the shared /quests cache. Polling is driven by useQuestPolling
   // in JobsRail (globally mounted in Frame) — adding another refetchInterval
   // here would force the shared query to 2s even when nothing is active.
   const { data: questsData } = useGetQuests();
   const ping = !!pingData;
+  const isLoading = appListLoading || pingLoading;
   const [sideloadManifest, setSideloadManifest] = useState<string | null>(null);
   const [sideloadPickerOpen, setSideloadPickerOpen] = useState(false);
   const [sideloadRunning, setSideloadRunning] = useState(false);
@@ -155,7 +138,10 @@ export default function InstalledApps() {
     };
   }, []);
 
-  if (!ping)
+  // Only surface "not ready" once the ping has actually settled without a pong.
+  // While it's still in flight we fall through to the skeleton, so a reload goes
+  // straight from skeleton to data — no "services not ready" flash in between.
+  if (!pingLoading && !ping)
     return (
       <div className="py-20 text-center">
         <p className="text-muted">FLECS services are not ready. Please try again in a moment.</p>
@@ -233,9 +219,9 @@ export default function InstalledApps() {
         </div>
       )}
 
-      {appListLoading && ping && allApps.length === 0 ? (
+      {isLoading && allApps.length === 0 ? (
         <RowSkeleton />
-      ) : allApps.length === 0 && !appListLoading ? (
+      ) : allApps.length === 0 ? (
         <div className="rounded-xl border border-white/10">
           <EmptyApps onSideload={() => setSideloadPickerOpen(true)} />
         </div>

--- a/src/pages/OAuthCallback.test.tsx
+++ b/src/pages/OAuthCallback.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * OAuth callback — must NOT show a separate "Completing sign in" gear screen.
+ * It renders the same skeleton the app lands on, so sign-in reads as one
+ * continuous loading state (skeleton → data) with nothing flashing in between.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { renderWithProviders } from '@test/test-utils';
+
+const authState = {
+  isAuthenticated: false,
+  isLoading: false,
+  user: null,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+  isConfigReady: true,
+  handleOAuthCallback: vi.fn().mockResolvedValue(undefined),
+  clearError: vi.fn(),
+  refreshAuthState: vi.fn(),
+  error: null,
+};
+
+vi.mock('@features/auth/AuthProvider', () => ({
+  useOAuth4WebApiAuth: () => authState,
+}));
+
+const { navigate, toastError } = vi.hoisted(() => ({ navigate: vi.fn(), toastError: vi.fn() }));
+vi.mock('react-router-dom', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('react-router-dom')>()),
+  useNavigate: () => navigate,
+}));
+vi.mock('sonner', () => ({ toast: { error: toastError } }));
+
+import OAuthCallback from './OAuthCallback';
+
+describe('OAuthCallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    authState.handleOAuthCallback.mockResolvedValue(undefined);
+  });
+
+  it('renders the app skeleton, not a separate "completing sign in" gear screen', () => {
+    const { container } = renderWithProviders(<OAuthCallback />, { route: '/oauth/callback' });
+
+    expect(screen.queryByText(/completing sign in/i)).toBeNull();
+    expect(container.querySelector('.animate-pulse')).toBeTruthy();
+  });
+
+  it('drops back to login with a toast when the token exchange fails', async () => {
+    authState.handleOAuthCallback.mockRejectedValueOnce(new Error('bad code'));
+    renderWithProviders(<OAuthCallback />, { route: '/oauth/callback' });
+
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/', { replace: true }));
+    expect(toastError).toHaveBeenCalledWith('bad code');
+  });
+});

--- a/src/pages/OAuthCallback.tsx
+++ b/src/pages/OAuthCallback.tsx
@@ -1,36 +1,27 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { toast } from 'sonner';
 import { useOAuth4WebApiAuth } from '@features/auth/AuthProvider';
+import RowSkeleton from '@features/apps/components/RowSkeleton';
 
 export default function OAuthCallback() {
   const { handleOAuthCallback, isConfigReady } = useOAuth4WebApiAuth();
-  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
   const ran = useRef(false);
 
   useEffect(() => {
     if (!isConfigReady || ran.current) return;
     ran.current = true;
-    handleOAuthCallback().catch((e) => setError(e?.message || 'Auth failed'));
-  }, [isConfigReady, handleOAuthCallback]);
+    // On success handleOAuthCallback reloads into the app, which keeps showing its
+    // skeleton until data lands — so the whole sign-in reads as one loading state.
+    // On failure, drop back to the login screen instead of a dead-end error page.
+    handleOAuthCallback().catch((e) => {
+      toast.error(e?.message || 'Sign in failed. Please try again.');
+      navigate('/', { replace: true });
+    });
+  }, [isConfigReady, handleOAuthCallback, navigate]);
 
-  if (error)
-    return (
-      <div className="flex justify-center items-center min-h-screen text-center">
-        <div>
-          <p className="text-error font-semibold">Authentication Failed</p>
-          <p className="mt-2 text-sm text-muted">{error}</p>
-          <a href="/" className="mt-4 inline-block text-brand text-sm hover:underline">
-            Return home
-          </a>
-        </div>
-      </div>
-    );
-
-  return (
-    <div className="flex justify-center items-center min-h-screen text-center">
-      <div>
-        <div className="animate-spin h-6 w-6 border-2 border-brand border-t-transparent rounded-full mx-auto" />
-        <p className="mt-4 text-sm">Completing sign in...</p>
-      </div>
-    </div>
-  );
+  // No separate "Completing sign in" screen — render the same skeleton the app
+  // lands on, so there is no flicker between auth and the loaded page.
+  return <RowSkeleton />;
 }


### PR DESCRIPTION
Removes the flicker on login and on reload by replacing every intermediate spinner/placeholder screen in the auth → app path with the app's own skeleton, so the user sees one continuous **skeleton → data** transition.

## Fixes
- **Reload flash:** `InstalledApps` showed *"FLECS services are not ready"* on every reload because `ping = !!pingData` treated the in-flight ping the same as a failed one. It now only surfaces that message once the ping has actually *settled* without a pong — while loading it falls through to the skeleton.
- **Login "check state":** `OAuthCallback` no longer renders a separate *"Completing sign in…"* gear screen. It renders the same `RowSkeleton` the app lands on, and on failure drops back to the login screen with a toast instead of a dead-end error page.
- **Shared skeleton:** extracted `RowSkeleton` so the callback and the apps page use an identical placeholder — that sameness is what makes the transition seamless.

## Tests
- `InstalledApps`: shows the skeleton on load, never the "not ready" flash.
- `OAuthCallback`: renders the skeleton (not the gear); failure routes back to login.
- Full suite: 65 passing, tsc clean, 0 lint errors.