### PR TITLE
feat: sort marketplace and installed apps alphabetically

### DIFF
--- a/src/pages/InstalledApps.tsx
+++ b/src/pages/InstalledApps.tsx
@@ -96,7 +96,13 @@ export default function InstalledApps() {
       .filter(Boolean);
   }, [questsData, installedApps]);
 
-  const allApps = [...installedApps, ...installingApps] as EnrichedApp[];
+  const allApps = useMemo(() => {
+    const combined = [...installedApps, ...installingApps] as EnrichedApp[];
+    const c = new Intl.Collator('en', { sensitivity: 'base', usage: 'sort' });
+    return combined.sort((a, b) =>
+      c.compare(a.title ?? a.appKey.name, b.title ?? b.appKey.name),
+    );
+  }, [installedApps, installingApps]);
   const appsWithUpdates = getAppsWithUpdates(installedApps);
   const updateCount = appsWithUpdates.length;
 

--- a/src/pages/InstalledApps.tsx
+++ b/src/pages/InstalledApps.tsx
@@ -99,9 +99,7 @@ export default function InstalledApps() {
   const allApps = useMemo(() => {
     const combined = [...installedApps, ...installingApps] as EnrichedApp[];
     const c = new Intl.Collator('en', { sensitivity: 'base', usage: 'sort' });
-    return combined.sort((a, b) =>
-      c.compare(a.title ?? a.appKey.name, b.title ?? b.appKey.name),
-    );
+    return combined.sort((a, b) => c.compare(a.title ?? a.appKey.name, b.title ?? b.appKey.name));
   }, [installedApps, installingApps]);
   const appsWithUpdates = getAppsWithUpdates(installedApps);
   const updateCount = appsWithUpdates.length;

--- a/src/pages/Marketplace.tsx
+++ b/src/pages/Marketplace.tsx
@@ -8,6 +8,7 @@ import {
   filterByPrice,
   filterByCategories,
   getUniqueCategories,
+  sortByName,
 } from '@stores/marketplace-filters';
 import { useGetSystemInfo } from '@generated/core/system/system';
 import type { Product } from '@generated/console/schemas';
@@ -116,7 +117,7 @@ export default function Marketplace() {
   ]);
 
   const finalProducts = useMemo(
-    () => filterByCategories(baseFiltered, filterParams.hiddenCategories),
+    () => sortByName(filterByCategories(baseFiltered, filterParams.hiddenCategories)),
     [baseFiltered, filterParams.hiddenCategories],
   );
 

--- a/src/stores/marketplace-filters.ts
+++ b/src/stores/marketplace-filters.ts
@@ -38,6 +38,12 @@ interface MarketplaceFiltersState {
 // ── Pure filter helpers — imported by the Marketplace page for useMemo derivation.
 // Server state (products, arch) is never stored here; we only transform it. ──
 
+const collator = new Intl.Collator('en', { sensitivity: 'base', usage: 'sort' });
+
+export function sortByName<T extends { name?: string }>(items: T[]): T[] {
+  return [...items].sort((a, b) => collator.compare(a.name ?? '', b.name ?? ''));
+}
+
 export function searchProducts(
   products: Product[],
   search: string,


### PR DESCRIPTION
## Summary

- Add `sortByName` pure utility with `Intl.Collator` to `marketplace-filters.ts`
- Apply sort to the full filtered product list in Marketplace before pagination slices it
- Sort installed + installing entries in InstalledApps by `title ?? appKey.name`

## Notes

Sort is always-on ascending — no state, no toggle. `Intl.Collator` with `sensitivity: 'base'` handles case and accent folding correctly. The `appKey.name` fallback guards against `title` being undefined while the WooCommerce product is still loading.