### PR TITLE
fix: migrate shell and layout components to semantic tokens

### DIFF
--- a/src/app/components/CollapsableRow.tsx
+++ b/src/app/components/CollapsableRow.tsx
@@ -15,7 +15,7 @@ export default function CollapsableRow({ title, children }: CollapsableRowProps)
           <button
             data-testid="expand-button"
             aria-label="expand row"
-            className="p-1 rounded-lg hover:bg-white/10 transition mr-2 inline-flex"
+            className="p-1 rounded-lg hover:bg-surface-hover transition mr-2 inline-flex"
             onClick={() => setOpen(!open)}
           >
             {open ? <ChevronUp size={20} /> : <ChevronDown size={20} />}

--- a/src/app/components/ContentDialog.tsx
+++ b/src/app/components/ContentDialog.tsx
@@ -17,13 +17,13 @@ function ContentDialog({ title, open, setOpen, actions, children }: ContentDialo
       onClick={() => setOpen(false)}
     >
       <div
-        className="bg-dark-end rounded-2xl max-w-4xl w-full max-h-[90vh] flex flex-col shadow-2xl border border-white/10"
+        className="bg-surface-raised rounded-2xl max-w-4xl w-full max-h-[90vh] flex flex-col shadow-2xl border border-border"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-6 py-4 border-b border-white/10">
+        <div className="px-6 py-4 border-b border-border">
           <h3 className="text-lg font-semibold">{title}</h3>
         </div>
-        <div className="flex-1 overflow-auto px-6 py-4 border-b border-white/10">
+        <div className="flex-1 overflow-auto px-6 py-4 border-b border-border">
           {children ?? <p className="text-sm text-muted">No content to display.</p>}
         </div>
         <div className="px-6 py-3 flex justify-end gap-2">

--- a/src/app/components/LoadIconButton.tsx
+++ b/src/app/components/LoadIconButton.tsx
@@ -26,7 +26,7 @@ const LoadIconButton: React.FC<LoadIconButtonProps> = ({
         data-testid="icon-button"
         disabled={disabled}
         onClick={() => onClick()}
-        className="p-1.5 rounded-lg hover:bg-white/10 transition"
+        className="p-1.5 rounded-lg hover:bg-surface-hover transition"
         style={{ display: displaystate }}
       >
         {icon}

--- a/src/app/components/SettingsCard.tsx
+++ b/src/app/components/SettingsCard.tsx
@@ -19,7 +19,7 @@ export default function SettingsCard({
 }: SettingsCardProps) {
   return (
     <div
-      className={`rounded-xl border overflow-hidden ${danger ? 'border-error' : 'border-white/10'}`}
+      className={`rounded-xl border overflow-hidden ${danger ? 'border-error' : 'border-border'}`}
     >
       {/* Content */}
       <div className={`px-6 pt-6 ${children ? 'pb-6' : 'pb-4'}`}>
@@ -32,7 +32,7 @@ export default function SettingsCard({
       {(footer || footerAction) && (
         <div
           className={`flex items-center px-6 py-3.5 border-t ${
-            danger ? 'border-error bg-error/5' : 'border-white/10 bg-white/[0.02]'
+            danger ? 'border-error bg-error/5' : 'border-border bg-surface-subtle'
           }`}
         >
           {footer && <span className="flex-1 text-xs text-muted">{footer}</span>}

--- a/src/app/layout/AppBar.tsx
+++ b/src/app/layout/AppBar.tsx
@@ -18,10 +18,10 @@ export default function MobileBar() {
   if (!isMobile) return null;
 
   return (
-    <header className="fixed top-0 left-0 right-0 z-50 bg-dark border-b border-white/8">
+    <header className="fixed top-0 left-0 right-0 z-50 bg-surface border-b border-border">
       <div className="flex items-center gap-2 h-12 px-2">
         <button
-          className="p-1.5 rounded-lg hover:bg-white/10 transition text-muted"
+          className="p-1.5 rounded-lg hover:bg-surface-hover transition text-muted"
           onClick={toggleSidebar}
           aria-label="Toggle sidebar"
         >

--- a/src/app/layout/Avatar.tsx
+++ b/src/app/layout/Avatar.tsx
@@ -58,7 +58,7 @@ export default function Avatar() {
       <button
         aria-label="avatar-button"
         onClick={user?.user ? () => setMenuOpen(!menuOpen) : handleSignIn}
-        className="p-1.5 rounded-lg hover:bg-white/10 transition text-white"
+        className="p-1.5 rounded-lg hover:bg-surface-hover transition text-white"
       >
         {user?.user ? (
           <User size={20} aria-label="user-menu-button" />
@@ -70,21 +70,21 @@ export default function Avatar() {
       {menuOpen && user?.user && (
         <div
           aria-label="user-menu"
-          className="absolute right-0 top-full mt-1 w-48 rounded-xl bg-dark-end border border-white/10 shadow-xl z-50 py-1 overflow-hidden"
+          className="absolute right-0 top-full mt-1 w-48 rounded-xl bg-surface-raised border border-border shadow-xl z-50 py-1 overflow-hidden"
         >
-          <div className="px-4 py-2 border-b border-white/10">
+          <div className="px-4 py-2 border-b border-border">
             <p className="text-xs text-muted">Signed in as</p>
             <p className="text-xs font-semibold">{user.user?.preferred_username || 'anonymous'}</p>
           </div>
           <button
             onClick={handleProfile}
-            className="w-full text-left px-4 py-2 text-sm hover:bg-white/5 transition"
+            className="w-full text-left px-4 py-2 text-sm hover:bg-surface-hover transition"
           >
             Profile
           </button>
           <button
             onClick={handleSignout}
-            className="w-full text-left px-4 py-2 text-sm hover:bg-white/5 transition"
+            className="w-full text-left px-4 py-2 text-sm hover:bg-surface-hover transition"
           >
             Sign out
           </button>

--- a/src/app/layout/CommandPalette.tsx
+++ b/src/app/layout/CommandPalette.tsx
@@ -142,10 +142,10 @@ export default function CommandPalette() {
 
       {/* Dialog */}
       <div
-        className="fixed top-[20%] left-1/2 -translate-x-1/2 w-full max-w-lg rounded-xl bg-dark-end border border-white/10 shadow-2xl z-[1301] overflow-hidden"
+        className="fixed top-[20%] left-1/2 -translate-x-1/2 w-full max-w-lg rounded-xl bg-surface-raised border border-border shadow-2xl z-[1301] overflow-hidden"
         aria-label="Command palette"
       >
-        <div className="flex items-center px-4 py-3 border-b border-white/10">
+        <div className="flex items-center px-4 py-3 border-b border-border">
           <Search size={20} className="mr-3 opacity-50" />
           <input
             ref={inputRef}
@@ -157,7 +157,7 @@ export default function CommandPalette() {
             onKeyDown={handleKeyDown}
             aria-label="Search commands"
           />
-          <span className="ml-2 px-1.5 py-0.5 rounded border border-white/10 text-[11px] text-muted">
+          <span className="ml-2 px-1.5 py-0.5 rounded border border-border text-[11px] text-muted">
             ESC
           </span>
         </div>
@@ -175,7 +175,7 @@ export default function CommandPalette() {
               aria-selected={index === selectedIndex}
               onClick={item.action}
               className={`flex items-center w-[calc(100%-16px)] mx-2 px-3 py-2 rounded-md transition ${
-                index === selectedIndex ? 'bg-brand/15' : 'hover:bg-white/5'
+                index === selectedIndex ? 'bg-brand/15' : 'hover:bg-surface-hover'
               }`}
             >
               <span className="w-9 shrink-0 flex justify-center">{item.icon}</span>

--- a/src/app/layout/HelpButton.tsx
+++ b/src/app/layout/HelpButton.tsx
@@ -15,7 +15,7 @@ const HelpButton: React.FC<HelpButtonProps> = ({ url, label = 'Help', ...props }
     <button
       title={label}
       onClick={handleClick}
-      className="p-1.5 rounded-lg hover:bg-white/10 transition"
+      className="p-1.5 rounded-lg hover:bg-surface-hover transition"
       {...props}
     >
       <HelpCircle size={20} />

--- a/src/app/layout/PoweredBy.tsx
+++ b/src/app/layout/PoweredBy.tsx
@@ -42,7 +42,7 @@ const PoweredByFLECS: React.FC = () => {
           href="https://flecs.tech"
           target="_blank"
           rel="noopener noreferrer"
-          className="inline-flex items-center no-underline px-3 py-1.5 rounded-lg border border-brand bg-dark-end hover:bg-dark transition"
+          className="inline-flex items-center no-underline px-3 py-1.5 rounded-lg border border-brand bg-surface-raised hover:bg-surface-hover transition"
         >
           <FLECSLogo />
           <span className="ml-2 text-sm transition">powered by FLECS</span>

--- a/src/index.css
+++ b/src/index.css
@@ -23,6 +23,7 @@
   --color-surface: #f9f8ff;
   --color-surface-raised: #ffffff;
   --color-surface-overlay: #f0effe;
+  --color-surface-subtle: rgba(11, 11, 24, 0.02);
   --color-surface-hover: rgba(11, 11, 24, 0.04);
 
   /* Semantic borders — light mode defaults */
@@ -59,6 +60,7 @@
     --color-surface: #0b0b18;
     --color-surface-raised: #1a1a2e;
     --color-surface-overlay: #1e1e34;
+    --color-surface-subtle: rgba(255, 255, 255, 0.02);
     --color-surface-hover: rgba(255, 255, 255, 0.05);
 
     /* Semantic borders — dark overrides */


### PR DESCRIPTION
## Summary

- Adds `--color-surface-subtle` token to the design system (very faint tint for card footers etc.)
- Replaces all hardcoded dark values in shell/layout components with semantic tokens

## Components updated

`ContentDialog`, `SettingsCard`, `CollapsableRow`, `LoadIconButton`, `AppBar`, `Avatar`, `CommandPalette`, `HelpButton`, `PoweredBy`

## Token mapping

| Before | After |
|---|---|
| `bg-dark-end` | `bg-surface-raised` |
| `border-white/10` | `border-border` |
| `hover:bg-white/5` | `hover:bg-surface-hover` |
| `hover:bg-white/10` | `hover:bg-surface-hover` |
| `bg-white/2` | `bg-surface-subtle` |

**Stacked on:** `fix/light-mode-toggle`