### PR TITLE
fix: rename Download App Config→Download Apps, Import Config→Import Apps

### DIFF
--- a/e2e/smoke/TC09-import-multipart.spec.ts
+++ b/e2e/smoke/TC09-import-multipart.spec.ts
@@ -25,7 +25,7 @@ test.describe('@smoke TC09 — import uses multipart content-type', () => {
     );
 
     await page.goto('/');
-    await page.getByRole('button', { name: /import config/i }).click();
+    await page.getByRole('button', { name: /import apps/i }).click();
 
     await page.setInputFiles('input[type="file"][accept*=".tar"]', {
       name: 'export.tar',

--- a/e2e/smoke/TC19-error-surfacing.spec.ts
+++ b/e2e/smoke/TC19-error-surfacing.spec.ts
@@ -20,7 +20,7 @@ test.describe('@smoke TC19 — error toast shows server reason', () => {
     );
 
     await page.goto('/');
-    await page.getByRole('button', { name: /import config/i }).click();
+    await page.getByRole('button', { name: /import apps/i }).click();
     await page.setInputFiles('input[type="file"][accept*=".tar"]', {
       name: 'bad.tar',
       mimeType: 'application/x-tar',

--- a/src/features/system/components/QuickActions.tsx
+++ b/src/features/system/components/QuickActions.tsx
@@ -8,7 +8,7 @@ export default function QuickActions() {
     <div className="rounded-xl bg-surface-raised p-6 border border-border">
       <h6 className="text-base font-semibold mb-4">Quick Actions</h6>
       <div className="flex items-center gap-4 flex-wrap">
-        <span title="Export all apps and data from this device">
+        <span title="Download apps from this device">
           <Export />
         </span>
         <span title="Import apps from a backup file">

--- a/src/features/system/components/data-transfer/Export.tsx
+++ b/src/features/system/components/data-transfer/Export.tsx
@@ -96,7 +96,7 @@ const Export: React.FC<ExportProps> = (props) => {
       ) : (
         <FolderDown size={16} />
       )}
-      {exporting ? 'Downloading...' : 'Download App Config'}
+      {exporting ? 'Downloading...' : 'Download Apps'}
     </button>
   );
 };

--- a/src/features/system/components/data-transfer/Import.test.tsx
+++ b/src/features/system/components/data-transfer/Import.test.tsx
@@ -35,7 +35,7 @@ describe('Import dropzone', () => {
   it('renders as a plain button without the dropzone prop', () => {
     renderWithProviders(<Import />);
     expect(screen.queryByTestId('import-dropzone')).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /import config/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /import apps/i })).toBeInTheDocument();
   });
 
   it('imports a dropped .tar archive via the imports API', async () => {

--- a/src/features/system/components/data-transfer/Import.tsx
+++ b/src/features/system/components/data-transfer/Import.tsx
@@ -109,7 +109,7 @@ export default function Import(props: ImportProps) {
     <FileOpen
       {...buttonProps}
       data-testid="import-apps-button"
-      buttonText="Import Config"
+      buttonText="Import Apps"
       buttonIcon={<FolderUp size={16} />}
       accept=".tar.gz, .tar, .json"
       onConfirm={handleFileUpload}


### PR DESCRIPTION
## Summary
- Renames the export button label from "Download App Config" to "Download Apps"
- Renames the import button label from "Import Config" to "Import Apps"
- Updates the export span tooltip from "Export all apps and data from this device" to "Download apps from this device"