### PR TITLE
feat(installed): rename Download Apps to Export Apps

### DIFF
--- a/src/features/system/components/QuickActions.tsx
+++ b/src/features/system/components/QuickActions.tsx
@@ -8,7 +8,7 @@ export default function QuickActions() {
     <div className="rounded-xl bg-surface-raised p-6 border border-border">
       <h6 className="text-base font-semibold mb-4">Quick Actions</h6>
       <div className="flex items-center gap-4 flex-wrap">
-        <span title="Download apps from this device">
+        <span title="Export apps from this device">
           <Export />
         </span>
         <span title="Import apps from a backup file">

--- a/src/features/system/components/data-transfer/Export.tsx
+++ b/src/features/system/components/data-transfer/Export.tsx
@@ -96,7 +96,7 @@ const Export: React.FC<ExportProps> = (props) => {
       ) : (
         <FolderDown size={16} />
       )}
-      {exporting ? 'Downloading...' : 'Download Apps'}
+      {exporting ? 'Exporting...' : 'Export Apps'}
     </button>
   );
 };


### PR DESCRIPTION
## Summary
- Renames "Download Apps" button label to "Export Apps" in `Export.tsx`
- Updates loading state from "Downloading..." to "Exporting..."
- Updates tooltip in `QuickActions.tsx` from "Download apps from this device" to "Export apps from this device"