### PR TITLE
feat(apps): add multi-instance app management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ out
 src/assets/third-party-licenses.txt
 src/assets/sbom.json
 generated/
+test-results/
 
 # macOS Finder metadata
 .DS_Store

--- a/e2e/fixtures/mocks.ts
+++ b/e2e/fixtures/mocks.ts
@@ -7,6 +7,7 @@
 import type {
   InstalledApp,
   AppInstance,
+  AppManifest,
   AppStatus,
   SystemInfo,
   Quest,
@@ -16,7 +17,7 @@ import type {
 import type { Product } from '@generated/console/schemas';
 
 export const fixtures = {
-  // Core API returns SystemInfo as the raw body — customInstance wraps it into { data, status, headers }.
+  // Core API returns SystemInfo as the raw body - customInstance wraps it into { data, status, headers }.
   systemInfo: (override: Partial<SystemInfo> = {}): SystemInfo => ({
     arch: 'arm64',
     platform: 'Distroless',
@@ -44,7 +45,16 @@ export const fixtures = {
     ...override,
   }),
 
-  // Minimal WooCommerce Product shape — orval generates this from console OpenAPI.
+  manifest: (override: Partial<AppManifest> = {}): AppManifest => ({
+    _schemaVersion: '3.0.0',
+    app: 'tech.flecs.fence',
+    version: '0.3.0-rc.3',
+    image: 'flecs/fence:smoke',
+    multiInstance: false,
+    ...override,
+  }),
+
+  // Minimal WooCommerce Product shape - orval generates this from console OpenAPI.
   product: (override: Partial<Product> = {}): Product => ({
     id: 1,
     name: 'Test App',

--- a/e2e/fixtures/routes.ts
+++ b/e2e/fixtures/routes.ts
@@ -71,6 +71,14 @@ export async function mockHappyPath(page: Page): Promise<void> {
     route.fulfill({ json: [fixtures.instance()], status: 200 }),
   );
 
+  // Manifests
+  await page.route('**/api/v2/manifests', (route) =>
+    route.fulfill({ json: [fixtures.manifest()], status: 200 }),
+  );
+  await page.route('**/api/v2/manifests/*/*', (route) =>
+    route.fulfill({ json: fixtures.manifest(), status: 200 }),
+  );
+
   // Quests
   await page.route('**/api/v2/quests', (route) => route.fulfill({ json: [], status: 200 }));
 

--- a/e2e/smoke/TC21-multi-instance-management.spec.ts
+++ b/e2e/smoke/TC21-multi-instance-management.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * TC21 - Multi-instance apps are managed as first-class Installed Apps rows.
+ *
+ * Regression-locks the Installed Apps row model: a multi-instance app must not
+ * collapse `instances[]` to the first entry. Menus must operate on the row's
+ * concrete instance id, and Duplicate app must appear when the manifest marks
+ * the app as multi-instance capable.
+ */
+import { test, expect } from '@playwright/test';
+import { stubAuth, mockHappyPath } from '../fixtures/routes';
+import { fixtures } from '../fixtures/mocks';
+
+test.describe('@smoke TC21 - multi-instance management', () => {
+  test('duplicates multi-instance apps and scopes lifecycle actions to the row instance', async ({
+    page,
+  }) => {
+    await stubAuth(page);
+    await mockHappyPath(page);
+
+    const appKey = { name: 'tech.flecs.node-red', version: '1.0.0' };
+    const createBodies: unknown[] = [];
+    const startedInstances: string[] = [];
+    const stoppedInstances: string[] = [];
+
+    await page.route('**/api/v2/apps', (route) =>
+      route.fulfill({
+        json: [fixtures.installedApp({ appKey, multiInstance: true })],
+        status: 200,
+      }),
+    );
+    await page.route('**/api/v2/manifests', (route) =>
+      route.fulfill({
+        json: [
+          fixtures.manifest({
+            app: appKey.name,
+            version: appKey.version,
+            image: 'node-red:latest',
+            multiInstance: true,
+          }),
+        ],
+        status: 200,
+      }),
+    );
+    await page.route('**/api/v2/manifests/*/*', (route) =>
+      route.fulfill({
+        json: fixtures.manifest({
+          app: appKey.name,
+          version: appKey.version,
+          image: 'node-red:latest',
+          multiInstance: true,
+        }),
+        status: 200,
+      }),
+    );
+    await page.route('**/api/v2/instances', (route) =>
+      route.fulfill({
+        json: [
+          fixtures.instance({
+            instanceId: 'abc12345',
+            instanceName: 'production',
+            appKey,
+            status: 'running',
+            desired: 'running',
+          }),
+          fixtures.instance({
+            instanceId: 'def67890',
+            instanceName: 'staging',
+            appKey,
+            status: 'running',
+            desired: 'running',
+          }),
+        ],
+        status: 200,
+      }),
+    );
+    await page.route('**/api/v2/quests/*', (route) => {
+      const jobId = Number(route.request().url().split('/').pop());
+      return route.fulfill({
+        json: {
+          id: jobId,
+          description: 'multi-instance quest',
+          result: jobId === 101 ? 'new-instance-id' : undefined,
+          state: 'success',
+        },
+        status: 200,
+      });
+    });
+    await page.route('**/api/v2/instances/create', async (route) => {
+      createBodies.push(await route.request().postDataJSON());
+      return route.fulfill({ json: { jobId: 101 }, status: 202 });
+    });
+    await page.route('**/api/v2/instances/*/start', (route) => {
+      startedInstances.push(
+        route
+          .request()
+          .url()
+          .match(/instances\/([^/]+)\/start/)?.[1] ?? '',
+      );
+      return route.fulfill({ json: { jobId: 102 }, status: 202 });
+    });
+    await page.route('**/api/v2/instances/*/stop', (route) => {
+      stoppedInstances.push(
+        route
+          .request()
+          .url()
+          .match(/instances\/([^/]+)\/stop/)?.[1] ?? '',
+      );
+      return route.fulfill({ json: { jobId: 103 }, status: 202 });
+    });
+
+    await page.goto('/');
+    await expect(page.getByRole('heading', { name: /installed apps/i })).toBeVisible();
+    await expect(page.getByText('tech.flecs.node-red (production)')).toBeVisible();
+    await expect(page.getByText('tech.flecs.node-red (staging)')).toBeVisible();
+
+    await page.getByRole('button', { name: /staging actions/i }).click();
+    await page.getByRole('button', { name: /^stop$/i }).click();
+    await expect.poll(() => stoppedInstances).toEqual(['def67890']);
+
+    await page.getByRole('button', { name: /production actions/i }).click();
+    await page.getByRole('button', { name: /duplicate app/i }).click();
+    await expect(page.getByRole('heading', { name: /name this instance/i })).toBeVisible();
+    await page.getByLabel(/instance name/i).fill('main-controller');
+    await page.getByRole('button', { name: /create "main-controller"/i }).click();
+    await expect.poll(() => createBodies).toEqual([{ appKey, instanceName: 'main-controller' }]);
+    await expect.poll(() => startedInstances).toEqual(['new-instance-id']);
+  });
+});

--- a/src/app/components/ContentDialog.tsx
+++ b/src/app/components/ContentDialog.tsx
@@ -6,9 +6,17 @@ interface ContentDialogProps {
   setOpen: (open: boolean) => void;
   actions?: React.ReactNode;
   children?: React.ReactNode;
+  panelClassName?: string;
 }
 
-function ContentDialog({ title, open, setOpen, actions, children }: ContentDialogProps) {
+function ContentDialog({
+  title,
+  open,
+  setOpen,
+  actions,
+  children,
+  panelClassName,
+}: ContentDialogProps) {
   if (!open) return null;
 
   return createPortal(
@@ -17,7 +25,10 @@ function ContentDialog({ title, open, setOpen, actions, children }: ContentDialo
       onClick={() => setOpen(false)}
     >
       <div
-        className="bg-surface-raised rounded-2xl max-w-4xl w-full max-h-[90vh] flex flex-col shadow-2xl border border-border"
+        className={
+          panelClassName ??
+          'bg-surface-raised rounded-2xl max-w-4xl w-full max-h-[90vh] flex flex-col shadow-2xl border border-border'
+        }
         onClick={(e) => e.stopPropagation()}
       >
         <div className="px-6 py-4 border-b border-border">

--- a/src/features/apps/app-queries.ts
+++ b/src/features/apps/app-queries.ts
@@ -1,5 +1,5 @@
 /**
- * App list — uses TanStack useQueries with combine to merge 3 generated API calls.
+ * App list - uses TanStack useQueries with combine to merge generated API calls.
  * Zero custom hooks. Pure TanStack standardization.
  */
 import { useQueries } from '@tanstack/react-query';
@@ -49,7 +49,7 @@ function combineAppList(
   const instances: AppInstance[] = unwrapSuccess(iRes.data) ?? [];
 
   // Enrich device apps with marketplace metadata + instances.
-  // Sideloaded apps have no marketplace match — fall back to the app's own reverse-domain name.
+  // Sideloaded apps have no marketplace match - fall back to the app's own reverse-domain name.
   const appList: EnrichedApp[] = apps
     .filter((a) => a.appKey.name)
     .map((app) => {

--- a/src/features/apps/components/InstalledAppRow.tsx
+++ b/src/features/apps/components/InstalledAppRow.tsx
@@ -3,7 +3,7 @@ import { useState, useRef, useEffect, useLayoutEffect, type CSSProperties } from
 import { toast } from 'sonner';
 import ReactDOM from 'react-dom';
 import {
-  ExternalLink,
+  LayersPlus,
   MoreHorizontal,
   Play,
   Plus,
@@ -22,8 +22,10 @@ import UpdateButton from '@features/apps/components/actions/UpdateButton';
 import ContentDialog from '@app/components/ContentDialog';
 import ConfirmDialog from '@app/components/ConfirmDialog';
 import { useDeleteAppsApp } from '@generated/core/apps/apps';
+import { useGetManifestsAppNameVersion } from '@generated/core/manifests/manifests';
 import InstanceInfo from './instances/InstanceInfo';
 import InstanceConfigDialog, { type SectionKey } from './instances/InstanceConfigDialog';
+import InstanceNameDialog from './InstanceNameDialog';
 import { VersionSelector } from '@app/components/VersionSelector';
 import { createUrl } from '@features/apps/components/actions/EditorButton';
 import { useQuestActions } from '@features/notifications/quests/hooks';
@@ -32,6 +34,7 @@ import { getErrorMessage } from '@app/api/fetch-error';
 
 import { isFinishedOk as questStateFinishedOk } from '@features/notifications/quests/QuestItem';
 import {
+  useDeleteInstancesInstanceId,
   postInstancesCreate,
   postInstancesInstanceIdStart,
   postInstancesInstanceIdStop,
@@ -40,14 +43,28 @@ import type { JobMeta } from '@generated/core/schemas';
 
 interface InstalledAppRowProps {
   app: EnrichedApp;
+  instance?: AppInstance;
 }
 
-export default function InstalledAppRow({ app }: InstalledAppRowProps) {
+export default function InstalledAppRow({ app, instance }: InstalledAppRowProps) {
   const qc = useQueryClient();
   const { waitForQuest } = useQuestActions();
   const { mutateAsync: deleteApp } = useDeleteAppsApp();
+  const { mutateAsync: deleteInstance } = useDeleteInstancesInstanceId();
+  const { data: manifestResponse, isPending: manifestPending } = useGetManifestsAppNameVersion(
+    app.appKey.name,
+    app.appKey.version,
+    {
+      query: { staleTime: 300_000 },
+    },
+  );
+  const manifest = unwrapSuccess(manifestResponse);
   const isInstalling = app.status === 'installing';
-  const instance: AppInstance | undefined = (app.instances ?? [])[0];
+  const canDuplicateApp = manifest?.multiInstance === true;
+  const instanceCount = app.instances?.length ?? 0;
+  const isInstanceScopedApp = Boolean(instance && (canDuplicateApp || instanceCount > 1));
+  const isLastInstanceOfApp = isInstanceScopedApp && instanceCount <= 1;
+  const canShowAppUninstall = !instance || (!manifestPending && !isInstanceScopedApp);
   const isRunning = instance?.status === 'running';
   const isStopped = instance?.status === 'stopped';
   const hasEditors = (instance?.editors?.length ?? 0) > 0;
@@ -81,6 +98,8 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
   const [settingsSection, setSettingsSection] = useState<SectionKey | undefined>(undefined);
   const [busy, setBusy] = useState(false);
   const [confirmUninstall, setConfirmUninstall] = useState(false);
+  const [confirmDeleteInstance, setConfirmDeleteInstance] = useState(false);
+  const [duplicateOpen, setDuplicateOpen] = useState(false);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
@@ -144,12 +163,15 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
     }
   };
 
-  const handleCreateAndStart = async () => {
+  const handleCreateAndStart = async (instanceName?: string) => {
     setBusy(true);
     setMenuAnchor(false);
     try {
+      const trimmedInstanceName =
+        typeof instanceName === 'string' ? instanceName.trim() : undefined;
       const createQuest = await postInstancesCreate({
         appKey: { name: app.appKey.name, version: app.appKey.version },
+        ...(trimmedInstanceName ? { instanceName: trimmedInstanceName } : {}),
       });
       const createJobId = unwrapSuccess(createQuest)?.jobId;
       if (!createJobId) throw new Error('No jobId in create response');
@@ -170,12 +192,63 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
     }
   };
 
-  const selectedVersionNotInstalled = !app.installedVersions?.includes(selectedVersion.version);
+  const handleUninstallApp = async () => {
+    setBusy(true);
+    try {
+      const r = await deleteApp({
+        app: app.appKey.name,
+        params: { version: app.appKey.version },
+      });
+      const jobId = unwrapSuccess(r)?.jobId;
+      if (jobId) {
+        const result = await waitForQuest(jobId);
+        if (questStateFinishedOk(result.state)) toast.success(`${app.title} uninstalled`);
+        else toast.error(`Failed to uninstall ${app.title}`);
+      }
+      qc.invalidateQueries();
+    } catch (err: unknown) {
+      toast.error(`Failed to uninstall ${app.title}`, { description: getErrorMessage(err) });
+    } finally {
+      setBusy(false);
+    }
+  };
 
+  const handleDeleteInstance = async () => {
+    if (!instance) return;
+    setBusy(true);
+    try {
+      const r = await deleteInstance({ instanceId: instance.instanceId });
+      const jobId = unwrapSuccess(r)?.jobId;
+      if (jobId) {
+        const result = await waitForQuest(jobId);
+        if (questStateFinishedOk(result.state)) {
+          toast.success(`${instance.instanceName || app.title} deleted`);
+        } else {
+          toast.error(`Failed to delete ${instance.instanceName || app.title}`);
+        }
+      }
+      qc.invalidateQueries();
+    } catch (err: unknown) {
+      toast.error(`Failed to delete ${instance.instanceName || app.title}`, {
+        description: getErrorMessage(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const selectedVersionNotInstalled = !app.installedVersions?.includes(selectedVersion.version);
+  const instanceName = instance?.instanceName.trim();
+  const instanceDisplayName =
+    isInstanceScopedApp && instance ? instanceName || `Instance ${instance.instanceId}` : undefined;
+  const instanceActionName = instanceDisplayName || instance?.instanceId;
+  const rowActionLabel = instance
+    ? `${app.title} ${instanceActionName} actions`
+    : `${app.title} actions`;
   return (
     <>
       <div className="flex items-center gap-4 px-5 py-3 hover:bg-surface-hover transition">
-        {/* Avatar — image from marketplace, generic package icon for sideloaded apps */}
+        {/* Avatar - image from marketplace, generic package icon for sideloaded apps */}
         <div className="w-12 h-12 rounded-lg bg-surface-hover flex items-center justify-center text-muted border border-border overflow-hidden shrink-0">
           {app.avatar ? (
             <img src={app.avatar} alt={app.title} className="w-full h-full object-cover" />
@@ -186,7 +259,12 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
         {/* Identity */}
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-bold truncate">{app.title}</span>
+            <span className="text-sm truncate">
+              <span className="font-bold">{app.title}</span>
+              {instanceDisplayName && (
+                <span className="font-normal text-text-primary"> ({instanceDisplayName})</span>
+              )}
+            </span>
             {updateAvailable && (
               <span
                 className="px-2 py-0.5 rounded-full bg-accent/20 text-accent text-[0.65rem] font-semibold cursor-pointer inline-flex items-center gap-1"
@@ -232,7 +310,7 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
         <div className="relative">
           <button
             ref={btnRef}
-            aria-label={`${app.title} actions`}
+            aria-label={rowActionLabel}
             className="p-1.5 rounded-lg hover:bg-surface-hover transition text-muted cursor-pointer"
             onClick={() => setMenuAnchor(!menuAnchor)}
             disabled={busy}
@@ -246,10 +324,24 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
                 style={menuStyle}
                 className="w-48 rounded-xl bg-surface-raised border border-border shadow-xl z-[9999] py-1"
               >
+                {canDuplicateApp && (
+                  <>
+                    <button
+                      className="flex items-center gap-2 w-full px-3 py-2 text-sm font-medium hover:bg-surface-hover transition"
+                      onClick={() => {
+                        setMenuAnchor(false);
+                        setDuplicateOpen(true);
+                      }}
+                    >
+                      <LayersPlus size={16} /> Duplicate app
+                    </button>
+                    <hr className="border-border my-1" />
+                  </>
+                )}
                 {!instance && (
                   <button
                     className="flex items-center gap-2 w-full px-3 py-2 text-sm hover:bg-surface-hover transition"
-                    onClick={handleCreateAndStart}
+                    onClick={() => handleCreateAndStart()}
                   >
                     <Plus size={16} /> Create & Start
                   </button>
@@ -291,7 +383,7 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
                       setSettingsOpen(true);
                     }}
                   >
-                    <Settings size={16} /> Settings
+                    <Settings size={16} /> Configure
                   </button>
                 )}
                 {instance && (
@@ -316,16 +408,32 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
                     <BookOpen size={16} /> Documentation
                   </button>
                 )}
-                <hr className="border-border my-1" />
-                <button
-                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-error hover:bg-surface-hover transition cursor-pointer"
-                  onClick={() => {
-                    setMenuAnchor(false);
-                    setConfirmUninstall(true);
-                  }}
-                >
-                  <Trash2 size={16} /> Uninstall
-                </button>
+                {(isInstanceScopedApp || canShowAppUninstall) && (
+                  <hr className="border-border my-1" />
+                )}
+                {isInstanceScopedApp && instance && (
+                  <button
+                    className="flex items-center gap-2 w-full px-3 py-2 text-sm text-error hover:bg-surface-hover transition cursor-pointer"
+                    onClick={() => {
+                      setMenuAnchor(false);
+                      setConfirmDeleteInstance(true);
+                    }}
+                  >
+                    <Trash2 size={16} />
+                    {isLastInstanceOfApp ? 'Uninstall app' : 'Delete instance'}
+                  </button>
+                )}
+                {canShowAppUninstall && (
+                  <button
+                    className="flex items-center gap-2 w-full px-3 py-2 text-sm text-error hover:bg-surface-hover transition cursor-pointer"
+                    onClick={() => {
+                      setMenuAnchor(false);
+                      setConfirmUninstall(true);
+                    }}
+                  >
+                    <Trash2 size={16} /> Uninstall app
+                  </button>
+                )}
               </div>,
               document.body,
             )}
@@ -370,35 +478,41 @@ export default function InstalledAppRow({ app }: InstalledAppRowProps) {
           />
         </>
       )}
+      <InstanceNameDialog
+        app={app}
+        open={duplicateOpen}
+        setOpen={setDuplicateOpen}
+        busy={busy}
+        onSubmit={handleCreateAndStart}
+      />
       <ConfirmDialog
         title={`Uninstall ${app.title}?`}
         open={confirmUninstall}
         setOpen={setConfirmUninstall}
-        confirmLabel="Uninstall"
+        confirmLabel="Uninstall app"
         confirmDestructive
-        onConfirm={async () => {
-          setBusy(true);
-          try {
-            const r = await deleteApp({
-              app: app.appKey.name,
-              params: { version: app.appKey.version },
-            });
-            const jobId = unwrapSuccess(r)?.jobId;
-            if (jobId) {
-              const result = await waitForQuest(jobId);
-              if (questStateFinishedOk(result.state)) toast.success(`${app.title} uninstalled`);
-              else toast.error(`Failed to uninstall ${app.title}`);
-            }
-            qc.invalidateQueries();
-          } catch (err: unknown) {
-            toast.error(`Failed to uninstall ${app.title}`, { description: getErrorMessage(err) });
-          } finally {
-            setBusy(false);
-          }
-        }}
+        onConfirm={handleUninstallApp}
       >
         This will remove {app.title} and all its data from your device.
       </ConfirmDialog>
+      {instance && (
+        <ConfirmDialog
+          title={
+            isLastInstanceOfApp
+              ? `Uninstall ${app.title}?`
+              : `Delete ${instance.instanceName || app.title} instance?`
+          }
+          open={confirmDeleteInstance}
+          setOpen={setConfirmDeleteInstance}
+          confirmLabel={isLastInstanceOfApp ? 'Uninstall app' : 'Delete instance'}
+          confirmDestructive
+          onConfirm={isLastInstanceOfApp ? handleUninstallApp : handleDeleteInstance}
+        >
+          {isLastInstanceOfApp
+            ? `This is the only ${app.title} instance. The app and its data will be removed from your device.`
+            : `This will remove only this instance and its data. Other ${app.title} instances remain installed.`}
+        </ConfirmDialog>
+      )}
     </>
   );
 }

--- a/src/features/apps/components/InstalledAppsTable.tsx
+++ b/src/features/apps/components/InstalledAppsTable.tsx
@@ -1,17 +1,37 @@
 import type { EnrichedApp } from '@features/apps/types';
 import InstalledAppRow from './InstalledAppRow';
+import type { AppInstance } from '@generated/core/schemas';
 
 interface InstalledAppsTableProps {
   apps: EnrichedApp[];
 }
 
+type InstalledAppListRow =
+  | { kind: 'app'; app: EnrichedApp; instance?: undefined }
+  | { kind: 'instance'; app: EnrichedApp; instance: AppInstance };
+
+function createInstalledAppRows(apps: EnrichedApp[]): InstalledAppListRow[] {
+  return apps.flatMap((app) => {
+    const instances = app.instances ?? [];
+    if (instances.length === 0) return [{ kind: 'app', app }];
+    return instances.map((instance) => ({ kind: 'instance', app, instance }));
+  });
+}
+
+function getRowKey(row: InstalledAppListRow) {
+  const appKey = `${row.app.appKey.name}:${row.app.appKey.version}`;
+  return row.kind === 'instance' ? `${appKey}:${row.instance.instanceId}` : `${appKey}:app`;
+}
+
 export default function InstalledAppsTable({ apps }: InstalledAppsTableProps) {
+  const rows = createInstalledAppRows(apps);
+
   return (
     <div className="rounded-xl border border-border overflow-hidden">
-      {apps.map((app, i) => (
-        <div key={app.appKey?.name + app.appKey?.version}>
+      {rows.map((row, i) => (
+        <div key={getRowKey(row)}>
           {i > 0 && <hr className="border-border" />}
-          <InstalledAppRow app={app} />
+          <InstalledAppRow app={row.app} instance={row.instance} />
         </div>
       ))}
     </div>

--- a/src/features/apps/components/InstanceNameDialog.tsx
+++ b/src/features/apps/components/InstanceNameDialog.tsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import { Lock, Package } from 'lucide-react';
+import ContentDialog from '@app/components/ContentDialog';
+import type { EnrichedApp } from '@features/apps/types';
+
+interface InstanceNameDialogProps {
+  app: EnrichedApp;
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  busy?: boolean;
+  onSubmit: (instanceName?: string) => void | Promise<void>;
+}
+
+export default function InstanceNameDialog({
+  app,
+  open,
+  setOpen,
+  busy,
+  onSubmit,
+}: InstanceNameDialogProps) {
+  const [instanceName, setInstanceName] = useState('');
+  const trimmedName = instanceName.trim();
+  const previewName = trimmedName || 'Unnamed instance';
+  const actionLabel = trimmedName ? `Create "${trimmedName}"` : 'Skip name';
+
+  const submit = async () => {
+    await onSubmit(trimmedName);
+    setOpen(false);
+    setInstanceName('');
+  };
+
+  return (
+    <ContentDialog
+      title="Name this instance"
+      open={open}
+      setOpen={setOpen}
+      panelClassName="bg-surface-raised rounded-2xl max-w-lg w-full max-h-[90vh] flex flex-col shadow-2xl border border-border overflow-hidden"
+      actions={
+        <>
+          <button
+            className="px-4 py-2 text-muted rounded-lg font-semibold hover:bg-surface-hover hover:text-text-primary transition text-sm"
+            onClick={() => setOpen(false)}
+            disabled={busy}
+          >
+            Cancel
+          </button>
+          <button
+            className="max-w-64 px-4 py-2 border border-brand bg-brand text-white rounded-lg font-semibold hover:bg-brand/90 transition text-sm disabled:opacity-40 disabled:cursor-not-allowed truncate"
+            onClick={submit}
+            disabled={busy}
+            title={actionLabel}
+          >
+            {actionLabel}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-5">
+        <p className="text-sm text-muted">
+          A name helps you tell this copy apart when you run the same app more than once.
+        </p>
+
+        <div>
+          <div className="flex items-baseline justify-between gap-3">
+            <label
+              htmlFor={`instance-name-${app.appKey.name}-${app.appKey.version}`}
+              className="text-sm font-semibold text-text-primary"
+            >
+              Instance name
+            </label>
+          </div>
+          <input
+            id={`instance-name-${app.appKey.name}-${app.appKey.version}`}
+            value={instanceName}
+            onChange={(event) => setInstanceName(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') void submit();
+            }}
+            placeholder="main-controller"
+            autoComplete="off"
+            spellCheck={false}
+            className="mt-2 h-11 w-full rounded-lg border border-border bg-surface px-3 text-sm font-mono outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/20"
+          />
+        </div>
+
+        <div className="flex items-center gap-2 text-xs text-muted">
+          <Lock size={14} className="shrink-0" />
+          <span>Names cannot be changed after the instance is created.</span>
+        </div>
+
+        <div className="rounded-xl border border-border bg-surface/40 p-3">
+          <div className="mb-2 text-[0.65rem] font-semibold uppercase tracking-wider text-muted">
+            Appears in your list as
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="w-9 h-9 rounded-lg bg-surface-hover flex items-center justify-center text-muted border border-border overflow-hidden shrink-0">
+              {app.avatar ? (
+                <img src={app.avatar} alt="" className="w-full h-full object-cover" />
+              ) : (
+                <Package size={17} className="text-brand" />
+              )}
+            </div>
+            <div className="min-w-0">
+              <div
+                className={`text-sm truncate ${trimmedName ? 'text-text-primary' : 'text-muted'}`}
+              >
+                <span className="font-bold">{app.title}</span>
+                <span className="font-normal"> ({previewName})</span>
+              </div>
+              <div className="flex items-center gap-1 text-xs text-muted">
+                {app.author && <span className="truncate">{app.author}</span>}
+                {app.author && <span>-</span>}
+                <span className="font-mono truncate">v{app.appKey?.version}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </ContentDialog>
+  );
+}

--- a/src/features/apps/components/InstanceNameDialog.tsx
+++ b/src/features/apps/components/InstanceNameDialog.tsx
@@ -20,7 +20,7 @@ export default function InstanceNameDialog({
 }: InstanceNameDialogProps) {
   const [instanceName, setInstanceName] = useState('');
   const trimmedName = instanceName.trim();
-  const previewName = trimmedName || 'Unnamed instance';
+  const previewName = trimmedName || 'Instance abcd1234';
   const actionLabel = trimmedName ? `Create "${trimmedName}"` : 'Skip name';
 
   const submit = async () => {

--- a/src/pages/InstalledApps.test.tsx
+++ b/src/pages/InstalledApps.test.tsx
@@ -1,9 +1,13 @@
 /**
- * Installed Apps — integration test.
+ * Installed Apps - integration test.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '@test/test-utils';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '@test/msw-setup';
+import { getGetManifestsAppNameVersionMockHandler } from '@generated/core/manifests/manifests.msw';
 
 vi.mock('@features/auth/AuthProvider', () => ({
   useOAuth4WebApiAuth: () => ({
@@ -23,6 +27,121 @@ vi.mock('@features/auth/AuthProvider', () => ({
 import InstalledApps from './InstalledApps';
 import { fireEvent } from '@testing-library/react';
 
+const MULTI_APP = {
+  appKey: { name: 'tech.flecs.node-red', version: '1.0.0' },
+  status: 'installed',
+  desired: 'installed',
+  installedSize: 1024,
+  multiInstance: false,
+};
+
+const SINGLE_APP = {
+  appKey: { name: 'tech.flecs.single', version: '1.0.0' },
+  status: 'installed',
+  desired: 'installed',
+  installedSize: 1024,
+  multiInstance: false,
+};
+
+const INSTANCE_A = {
+  instanceId: 'abc12345',
+  instanceName: 'production',
+  appKey: MULTI_APP.appKey,
+  status: 'running',
+  desired: 'running',
+  editors: [],
+};
+
+const INSTANCE_B = {
+  instanceId: 'def67890',
+  instanceName: 'staging',
+  appKey: MULTI_APP.appKey,
+  status: 'stopped',
+  desired: 'stopped',
+  editors: [],
+};
+
+const MULTI_MANIFEST = {
+  _schemaVersion: '3.0.0',
+  app: MULTI_APP.appKey.name,
+  version: MULTI_APP.appKey.version,
+  image: 'node-red:latest',
+  multiInstance: true,
+};
+
+const SINGLE_MANIFEST = {
+  _schemaVersion: '3.0.0',
+  app: SINGLE_APP.appKey.name,
+  version: SINGLE_APP.appKey.version,
+  image: 'single:latest',
+  multiInstance: false,
+};
+
+function mockInstalledApps(overrides?: {
+  apps?: unknown[];
+  instances?: unknown[];
+  onCreate?: (body: unknown) => void;
+  onStart?: (instanceId: string) => void;
+  onDeleteApp?: (app: string) => void;
+  onDeleteInstance?: (instanceId: string) => void;
+}) {
+  const manifests = [MULTI_MANIFEST, SINGLE_MANIFEST];
+  server.use(
+    http.get('*/apps', () => HttpResponse.json(overrides?.apps ?? [MULTI_APP])),
+    http.get('*/instances', () =>
+      HttpResponse.json(overrides?.instances ?? [INSTANCE_A, INSTANCE_B]),
+    ),
+    getGetManifestsAppNameVersionMockHandler(
+      ({ params }) =>
+        manifests.find(
+          (manifest) => manifest.app === params.appName && manifest.version === params.version,
+        ) ?? {
+          _schemaVersion: '3.0.0',
+          app: String(params.appName),
+          version: String(params.version),
+          image: 'unknown:latest',
+          multiInstance: false,
+        },
+    ),
+    http.get('*/quests/:id', ({ params }) =>
+      HttpResponse.json({
+        id: Number(params.id),
+        description: 'quest',
+        result: params.id === '101' ? 'new-instance-id' : undefined,
+        state: 'success',
+      }),
+    ),
+    http.post('*/instances/create', async ({ request }) => {
+      const body = await request.json();
+      overrides?.onCreate?.(body);
+      return HttpResponse.json({ jobId: 101 }, { status: 202 });
+    }),
+    http.post('*/instances/:instanceId/start', ({ params }) => {
+      overrides?.onStart?.(String(params.instanceId));
+      return HttpResponse.json({ jobId: 102 }, { status: 202 });
+    }),
+    http.delete('*/apps/:app', ({ params }) => {
+      overrides?.onDeleteApp?.(String(params.app));
+      return HttpResponse.json({ jobId: 201 }, { status: 202 });
+    }),
+    http.delete('*/instances/:instanceId', ({ params }) => {
+      overrides?.onDeleteInstance?.(String(params.instanceId));
+      return HttpResponse.json({ jobId: 202 }, { status: 202 });
+    }),
+  );
+}
+
+async function findInstalledRowTitle(appName: string, instanceName: string) {
+  const title = `${appName} (${instanceName})`;
+  await waitFor(() => {
+    expect(
+      screen
+        .getAllByText((_, element) => element?.textContent === title)
+        .some((element) => element.className === 'text-sm truncate'),
+    ).toBe(true);
+  });
+}
+
 describe('Installed Apps', () => {
   it('renders installed apps heading', async () => {
     renderWithProviders(<InstalledApps />, { route: '/' });
@@ -33,7 +152,7 @@ describe('Installed Apps', () => {
 
   it('shows the skeleton while loading, never the "not ready" flash, then the data', async () => {
     // Regression: ping/app-list are in-flight on first render. The page must show
-    // the skeleton — not "FLECS services are not ready" — so a reload goes straight
+    // the skeleton - not "FLECS services are not ready" - so a reload goes straight
     // from skeleton to data with nothing flashing in between.
     const { container } = renderWithProviders(<InstalledApps />, { route: '/' });
 
@@ -70,5 +189,124 @@ describe('Installed Apps', () => {
     await waitFor(() => {
       expect(screen.queryByText('Installing Sideloaded App')).not.toBeInTheDocument();
     });
+  });
+
+  it('renders each app instance as its own installed app row', async () => {
+    mockInstalledApps();
+    renderWithProviders(<InstalledApps />, { route: '/' });
+
+    await findInstalledRowTitle('tech.flecs.node-red', 'production');
+    await findInstalledRowTitle('tech.flecs.node-red', 'staging');
+  });
+
+  it('shows Duplicate app when the generated manifests response marks the app multi-instance capable', async () => {
+    mockInstalledApps({
+      apps: [MULTI_APP, SINGLE_APP],
+      instances: [INSTANCE_A],
+    });
+    renderWithProviders(<InstalledApps />, { route: '/' });
+
+    await findInstalledRowTitle('tech.flecs.node-red', 'production');
+    const actionButtons = await screen.findAllByRole('button', { name: /actions/i });
+    await userEvent.click(actionButtons[0]);
+
+    expect(screen.getByRole('button', { name: /duplicate app/i })).toBeInTheDocument();
+  });
+
+  it('hides Duplicate app when the generated manifest does not claim multi-instance capability', async () => {
+    mockInstalledApps({
+      apps: [SINGLE_APP],
+      instances: [{ ...INSTANCE_A, appKey: SINGLE_APP.appKey }],
+    });
+    renderWithProviders(<InstalledApps />, { route: '/' });
+
+    await screen.findByText('tech.flecs.single');
+    expect(screen.queryByText('production')).not.toBeInTheDocument();
+    const actionButtons = await screen.findAllByRole('button', { name: /actions/i });
+    await userEvent.click(actionButtons[0]);
+
+    expect(screen.queryByRole('button', { name: /duplicate app/i })).not.toBeInTheDocument();
+  });
+
+  it('duplicates a multi-instance app with the generated create body and starts the new instance', async () => {
+    const onCreate = vi.fn();
+    const onStart = vi.fn();
+    mockInstalledApps({ onCreate, onStart });
+    renderWithProviders(<InstalledApps />, { route: '/' });
+
+    await findInstalledRowTitle('tech.flecs.node-red', 'production');
+    const actionButtons = await screen.findAllByRole('button', { name: /actions/i });
+    await userEvent.click(actionButtons[0]);
+    await userEvent.click(screen.getByRole('button', { name: /duplicate app/i }));
+    await userEvent.type(screen.getByLabelText(/instance name/i), 'main-controller');
+    await userEvent.click(screen.getByRole('button', { name: /create "main-controller"/i }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith({
+        appKey: { name: 'tech.flecs.node-red', version: '1.0.0' },
+        instanceName: 'main-controller',
+      }),
+    );
+    await waitFor(() => expect(onStart).toHaveBeenCalledWith('new-instance-id'));
+  });
+
+  it('allows creating a duplicate without an instance name', async () => {
+    const onCreate = vi.fn();
+    mockInstalledApps({ onCreate });
+    renderWithProviders(<InstalledApps />, { route: '/' });
+
+    await findInstalledRowTitle('tech.flecs.node-red', 'production');
+    const actionButtons = await screen.findAllByRole('button', { name: /actions/i });
+    await userEvent.click(actionButtons[0]);
+    await userEvent.click(screen.getByRole('button', { name: /duplicate app/i }));
+    expect(
+      screen.getByText(/cannot be changed after the instance is created/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Unnamed instance/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /^skip name$/i }));
+
+    await waitFor(() =>
+      expect(onCreate).toHaveBeenCalledWith({
+        appKey: { name: 'tech.flecs.node-red', version: '1.0.0' },
+      }),
+    );
+  });
+
+  it('deletes the row instance instead of uninstalling the whole multi-instance app', async () => {
+    const onDeleteApp = vi.fn();
+    const onDeleteInstance = vi.fn();
+    mockInstalledApps({ onDeleteApp, onDeleteInstance });
+    renderWithProviders(<InstalledApps />, { route: '/' });
+
+    await findInstalledRowTitle('tech.flecs.node-red', 'staging');
+    await userEvent.click(screen.getByRole('button', { name: /staging actions/i }));
+
+    expect(screen.queryByRole('button', { name: /uninstall app/i })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /delete instance/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^delete instance$/i }));
+
+    await waitFor(() => expect(onDeleteInstance).toHaveBeenCalledWith('def67890'));
+    expect(onDeleteApp).not.toHaveBeenCalled();
+  });
+
+  it('uninstalls the app when deleting the only remaining multi-instance app instance', async () => {
+    const onDeleteApp = vi.fn();
+    const onDeleteInstance = vi.fn();
+    mockInstalledApps({
+      instances: [INSTANCE_A],
+      onDeleteApp,
+      onDeleteInstance,
+    });
+    renderWithProviders(<InstalledApps />, { route: '/' });
+
+    await findInstalledRowTitle('tech.flecs.node-red', 'production');
+    await userEvent.click(screen.getByRole('button', { name: /production actions/i }));
+
+    expect(screen.queryByRole('button', { name: /delete instance/i })).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /uninstall app/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^uninstall app$/i }));
+
+    await waitFor(() => expect(onDeleteApp).toHaveBeenCalledWith('tech.flecs.node-red'));
+    expect(onDeleteInstance).not.toHaveBeenCalled();
   });
 });

--- a/src/pages/InstalledApps.test.tsx
+++ b/src/pages/InstalledApps.test.tsx
@@ -262,7 +262,7 @@ describe('Installed Apps', () => {
     expect(
       screen.getByText(/cannot be changed after the instance is created/i),
     ).toBeInTheDocument();
-    expect(screen.getByText(/Unnamed instance/)).toBeInTheDocument();
+    expect(screen.getByText(/Instance abcd1234/)).toBeInTheDocument();
     await userEvent.click(screen.getByRole('button', { name: /^skip name$/i }));
 
     await waitFor(() =>

--- a/src/pages/Marketplace.test.tsx
+++ b/src/pages/Marketplace.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Marketplace — integration test.
+ * Marketplace - integration test.
  * MSW returns generated mock products. Verify the page renders them.
  */
 import { describe, it, expect } from 'vitest';

--- a/src/test/msw-setup.ts
+++ b/src/test/msw-setup.ts
@@ -1,6 +1,10 @@
 import { setupServer } from 'msw/node';
 import { getAppsMock } from '@generated/core/apps/apps.msw';
 import { getInstancesMock } from '@generated/core/instances/instances.msw';
+import {
+  getGetManifestsAppNameVersionMockHandler,
+  getGetManifestsMockHandler,
+} from '@generated/core/manifests/manifests.msw';
 import { getSystemMock } from '@generated/core/system/system.msw';
 import { getDeviceMock } from '@generated/core/device/device.msw';
 import { getQuestsMock } from '@generated/core/quests/quests.msw';
@@ -10,10 +14,18 @@ import { getDeploymentsMock } from '@generated/core/deployments/deployments.msw'
 import { getFlecsportMock } from '@generated/core/flecsport/flecsport.msw';
 import { getJobsMock } from '@generated/core/jobs/jobs.msw';
 
-// All handlers generated from OpenAPI specs — zero manual mocks
+// All handlers generated from OpenAPI specs.
 export const server = setupServer(
   ...getAppsMock(),
   ...getInstancesMock(),
+  getGetManifestsMockHandler([]),
+  getGetManifestsAppNameVersionMockHandler((info) => ({
+    _schemaVersion: '3.0.0',
+    app: String(info.params.appName),
+    version: String(info.params.version),
+    image: 'test/image:latest',
+    multiInstance: false,
+  })),
   ...getSystemMock(),
   ...getDeviceMock(),
   ...getQuestsMock(),


### PR DESCRIPTION
## Summary
- render installed app instances as first-class rows in Installed Apps
- add a reusable instance-name dialog for duplicate app and first marketplace install flows
- create and start duplicate instances through the generated Orval instance endpoint, omitting instanceName when users skip naming
- scope destructive actions so multi-instance rows delete only that instance

## Validation
- npm test -- Marketplace.test.tsx InstalledApps.test.tsx
- npm run lint
- npm run build