### PR TITLE
fix(branding): render default logo reliably

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   smoke:
-    name: Playwright smoke (chromium)
+    name: Playwright smoke and brand rendering
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -22,14 +22,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright Chromium
-        run: npx playwright install --with-deps chromium
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox webkit
 
       - name: Generate orval types
         run: npm run generate
 
       - name: Run smoke suite
         run: npm run test:e2e:smoke
+
+      - name: Run cross-browser brand suite
+        run: npm run test:e2e:brand
 
       - name: Upload trace artifacts on failure
         if: failure()

--- a/e2e/cross-browser/brand-logo.spec.ts
+++ b/e2e/cross-browser/brand-logo.spec.ts
@@ -1,0 +1,38 @@
+import { test, expect } from '@playwright/test';
+import { mockHappyPath, stubAuth } from '../fixtures/routes';
+
+test.describe('default brand logo', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubAuth(page);
+    await mockHappyPath(page);
+  });
+
+  test('cold load renders the built-in logo without requesting a missing themed asset', async ({
+    page,
+  }) => {
+    const defaultLogoRequests: string[] = [];
+    page.on('request', (request) => {
+      if (new URL(request.url()).pathname.endsWith('/theming/logo.svg')) {
+        defaultLogoRequests.push(request.url());
+      }
+    });
+
+    await page.goto('/');
+    const sidebar = page.locator('aside');
+    await expect(sidebar.getByText('FLECS', { exact: true })).toBeVisible();
+
+    expect(defaultLogoRequests).toEqual([]);
+    await expect(sidebar.locator('img[src$="/theming/logo.svg"]')).toHaveCount(0);
+    await expect
+      .poll(() =>
+        sidebar
+          .locator('img')
+          .evaluateAll((images) =>
+            images
+              .filter((image) => image.complete && image.naturalWidth === 0)
+              .map((image) => image.currentSrc || image.src),
+          ),
+      )
+      .toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",
+    "test:e2e:brand": "playwright test --project=brand-chromium --project=brand-firefox --project=brand-webkit",
     "test:e2e:smoke": "playwright test --project smoke-dev",
     "test:e2e:smoke-prod": "PW_SMOKE_PROD=true playwright test --project smoke-prod",
     "lint": "eslint . && npm run lint:casts && npm run lint:csp",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -31,6 +31,11 @@ export default defineConfig({
       testDir: 'e2e/smoke',
       use: { baseURL: 'http://localhost:5173' },
     },
+    ...(['chromium', 'firefox', 'webkit'] as const).map((browserName) => ({
+      name: `brand-${browserName}`,
+      testDir: 'e2e/cross-browser',
+      use: { baseURL: 'http://localhost:5173', browserName },
+    })),
     // Tier 3 — production nginx image + built bundle. Catches security-header
     // regressions (WSTG CONF-12/14) that the dev tier cannot observe because
     // Vite does not set response headers. Opt-in via PW_SMOKE_PROD=true.

--- a/src/app/layout/Drawer.test.tsx
+++ b/src/app/layout/Drawer.test.tsx
@@ -120,6 +120,6 @@ describe('Drawer brand header', () => {
     );
 
     expect(screen.queryByText('Wordmark Manager')).not.toBeInTheDocument();
-    expect(screen.getByAltText('Wordmark Manager logo')).toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Wordmark Manager logo' })).toBeInTheDocument();
   });
 });

--- a/src/app/layout/Logo.test.tsx
+++ b/src/app/layout/Logo.test.tsx
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { TenantConfigSchema } from '../../tenant';
+import { TenantContext } from '@app/theme/TenantContext';
+import { ThemeHandler } from '@app/theme/ThemeHandler';
+import Logo from './Logo';
+
+beforeEach(() => {
+  window.matchMedia = (query: string): MediaQueryList => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    addListener: () => {},
+    removeListener: () => {},
+    dispatchEvent: () => false,
+  });
+});
+
+function renderLogo(tenant = TenantConfigSchema.parse({})) {
+  return render(
+    <TenantContext.Provider value={tenant}>
+      <ThemeHandler>
+        <Logo alt="Brand logo" />
+      </ThemeHandler>
+    </TenantContext.Provider>,
+  );
+}
+
+describe('Logo', () => {
+  it('renders the built-in FLECS mark immediately when no themed logo is configured', () => {
+    const { container } = renderLogo();
+
+    expect(container.querySelector('img')).not.toBeInTheDocument();
+    expect(screen.getByRole('img', { name: 'Brand logo' })).toBeVisible();
+    expect(container.querySelector('svg')).toBeVisible();
+  });
+
+  it('loads an explicitly configured themed logo', () => {
+    renderLogo(
+      TenantConfigSchema.parse({
+        branding: { logos: { default: 'custom-logo.svg' } },
+      }),
+    );
+
+    expect(screen.getByRole('img', { name: 'Brand logo' })).toHaveAttribute(
+      'src',
+      '/theming/custom-logo.svg',
+    );
+  });
+});

--- a/src/app/layout/Logo.tsx
+++ b/src/app/layout/Logo.tsx
@@ -22,10 +22,10 @@ export default function Logo({
 }: Props) {
   const { branding } = useTenant();
   const { isDarkMode } = useDarkMode();
-  const defaultLogo = branding.logos.default ?? 'logo.svg';
+  const defaultLogo = branding.logos.default;
   const modeLogo = isDarkMode ? branding.logos.dark : branding.logos.light;
   const preferredLogo = modeLogo ?? defaultLogo;
-  const [src, setSrc] = useState(preferredLogo);
+  const [src, setSrc] = useState<string | undefined>(preferredLogo);
   const [failed, setFailed] = useState(false);
 
   useEffect(() => {
@@ -33,9 +33,14 @@ export default function Logo({
     setFailed(false);
   }, [preferredLogo]);
 
-  if (failed) {
+  if (!src || failed) {
     return (
-      <span className={`inline-flex items-center justify-center ${className}`} style={style}>
+      <span
+        role={alt ? 'img' : undefined}
+        aria-label={alt || undefined}
+        className={`inline-flex items-center justify-center ${className}`}
+        style={style}
+      >
         <FLECSLogo logoColor={logoColor} size={fallbackSize} />
       </span>
     );
@@ -47,7 +52,7 @@ export default function Logo({
       className={`block object-contain ${className}`}
       style={style}
       onError={() => {
-        if (src !== defaultLogo) {
+        if (defaultLogo && src !== defaultLogo) {
           setSrc(defaultLogo);
           return;
         }


### PR DESCRIPTION
## Summary

- render the bundled FLECS SVG immediately when no tenant logo is configured
- stop requesting the nonexistent default /theming/logo.svg asset
- preserve explicit tenant logo loading and fallback behavior
- keep the inline fallback accessible when it has a meaningful label
- add fresh-context regression coverage for Chromium, Firefox, and WebKit

## Root cause

The default tenant does not provide public/theming/logo.svg, but the logo component requested it and waited for the image error event before rendering the bundled FLECS mark. The delayed failure exposed a broken-image state in Safari on localhost.

## Validation

- 3 cross-browser cold-load E2E tests passed
- 12 Chromium smoke E2E tests passed
- 127 unit and integration tests passed
- production build passed
- lint passed with no errors
- formatting and diff checks passed

## Branch

Independent fix based directly on main.