### PR TITLE
feat(apps): redesign instance configuration workflow

### DIFF
--- a/e2e/smoke/TC23-instance-configuration.spec.ts
+++ b/e2e/smoke/TC23-instance-configuration.spec.ts
@@ -1,0 +1,308 @@
+import { expect, test, type Page } from '@playwright/test';
+import { mockHappyPath, stubAuth } from '../fixtures/routes';
+import { fixtures } from '../fixtures/mocks';
+
+type Audit = {
+  writes: string[];
+  restarts: string[];
+};
+
+async function mockInstanceConfiguration(
+  page: Page,
+  audit: Audit,
+  running = true,
+  failEnvironment = false,
+) {
+  await stubAuth(page);
+  await mockHappyPath(page);
+  const instance = fixtures.instance({
+    status: running ? 'running' : 'stopped',
+    desired: running ? 'running' : 'stopped',
+  });
+
+  await page.route('**/api/v2/products/apps', (route) =>
+    route.fulfill({
+      json: {
+        statusCode: 200,
+        statusText: 'OK',
+        data: {
+          products: [
+            fixtures.product({
+              attributes: [
+                { id: 1, name: 'archs', options: ['arm64', 'amd64'] },
+                { id: 2, name: 'reverse-domain-name', options: ['tech.flecs.fence'] },
+                {
+                  id: 3,
+                  name: 'versions',
+                  options: ['0.4.0', '0.3.0-rc.3', '0.2.0'],
+                },
+              ],
+            }),
+          ],
+        },
+      },
+      status: 200,
+    }),
+  );
+  await page.route('**/api/v2/instances', (route) =>
+    route.fulfill({
+      json: [instance],
+      status: 200,
+    }),
+  );
+  await page.route('**/api/v2/instances/00000001', (route) =>
+    route.fulfill({ json: instance, status: 200 }),
+  );
+  await page.route('**/api/v2/system/devices/usb', (route) =>
+    route.fulfill({
+      json: [{ port: '1-1', name: 'Temperature sensor', vendor: 'FLECS Lab' }],
+      status: 200,
+    }),
+  );
+  await page.route('**/api/v2/instances/00000001/config/devices/usb', (route) =>
+    route.fulfill({ json: [], status: 200 }),
+  );
+  await page.route('**/api/v2/instances/00000001/config/devices/usb/*', (route) => {
+    audit.writes.push(`usb:${route.request().method()}`);
+    return route.fulfill({ json: {}, status: 200 });
+  });
+  await page.route('**/api/v2/instances/00000001/config/environment', async (route) => {
+    if (route.request().method() === 'PUT') {
+      audit.writes.push('environment:PUT');
+      if (failEnvironment) {
+        return route.fulfill({
+          json: { additionalInfo: 'Configuration rejected' },
+          status: 500,
+        });
+      }
+      return route.fulfill({ json: {}, status: 200 });
+    }
+    return route.fulfill({
+      json: [{ name: 'MODE', value: 'production' }],
+      status: 200,
+    });
+  });
+  await page.route('**/api/v2/instances/00000001/config/ports', (route) =>
+    route.fulfill({
+      json: { tcp: [{ host_port: 8080, container_port: 80 }], udp: [], sctp: [] },
+      status: 200,
+    }),
+  );
+  await page.route('**/api/v2/instances/00000001/config/ports/*', (route) => {
+    const protocol = route.request().url().split('/').pop();
+    audit.writes.push(`ports:${protocol}`);
+    return route.fulfill({ json: {}, status: 200 });
+  });
+  await page.route('**/api/v2/instances/00000001/stop', (route) => {
+    audit.restarts.push('stop');
+    return route.fulfill({ json: { jobId: 71 }, status: 202 });
+  });
+  await page.route('**/api/v2/instances/00000001/start', (route) => {
+    audit.restarts.push('start');
+    return route.fulfill({ json: { jobId: 72 }, status: 202 });
+  });
+  await page.route('**/api/v2/quests/*', (route) => {
+    const id = Number(route.request().url().split('/').pop());
+    return route.fulfill({
+      json: { id, description: 'Instance lifecycle', state: 'success' },
+      status: 200,
+    });
+  });
+}
+
+async function openSettings(page: Page) {
+  await page.goto('/');
+  await expect(page.getByRole('heading', { name: /installed apps/i })).toBeVisible();
+  await page
+    .getByRole('button', { name: /actions/i })
+    .first()
+    .click();
+  await page.getByRole('button', { name: 'Configure' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Instance settings' });
+  await expect(dialog).toBeVisible();
+  return dialog;
+}
+
+test.describe('@smoke TC23 - instance configuration', () => {
+  test('dismiss never saves or restarts and protects a local draft', async ({ page }) => {
+    const audit: Audit = { writes: [], restarts: [] };
+    await mockInstanceConfiguration(page, audit);
+    const dialog = await openSettings(page);
+
+    await dialog.getByRole('button', { name: 'Environment' }).click();
+    await dialog.getByLabel('Value for MODE').fill('staging');
+    await expect(dialog.getByText('1 unsaved change')).toBeVisible();
+    expect(audit.writes).toEqual([]);
+
+    await dialog.getByRole('button', { name: 'Close instance settings' }).click();
+    const discard = page.getByRole('dialog', { name: 'Discard changes?' });
+    await expect(discard).toBeVisible();
+    await discard.getByRole('button', { name: 'Keep editing' }).click();
+    await expect(dialog).toBeVisible();
+    expect(audit.writes).toEqual([]);
+    expect(audit.restarts).toEqual([]);
+  });
+
+  test('preserves drafts across sections and applies before an explicit restart', async ({
+    page,
+  }) => {
+    const audit: Audit = { writes: [], restarts: [] };
+    await mockInstanceConfiguration(page, audit);
+    const dialog = await openSettings(page);
+
+    await dialog.getByRole('button', { name: 'Environment' }).click();
+    await dialog.getByLabel('Value for MODE').fill('staging');
+    await dialog.getByRole('button', { name: 'USB Devices' }).click();
+    await dialog.getByRole('switch', { name: /temperature sensor/i }).click();
+    await dialog.getByRole('button', { name: 'Ports' }).click();
+    await dialog.getByLabel('Host port').fill('9090');
+
+    await expect(dialog.getByText('3 unsaved changes')).toBeVisible();
+    expect(audit.writes).toEqual([]);
+    await dialog.getByRole('button', { name: 'Apply & restart' }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page.getByText('default settings applied and instance restarting')).toBeVisible();
+    expect(audit.writes).toEqual(['environment:PUT', 'ports:tcp', 'usb:PUT']);
+    expect(audit.restarts).toEqual(['stop', 'start']);
+  });
+
+  test('keeps a staged USB choice when server queries refresh in the background', async ({
+    page,
+  }) => {
+    const audit: Audit = { writes: [], restarts: [] };
+    let usbReads = 0;
+    let serverReportsEnabled = false;
+    await mockInstanceConfiguration(page, audit);
+    await page.route('**/api/v2/instances/00000001/config/devices/usb', (route) => {
+      usbReads += 1;
+      return route.fulfill({
+        json: serverReportsEnabled
+          ? [
+              {
+                port: '1-1',
+                name: 'Temperature sensor',
+                vendor: 'FLECS Lab',
+                device_connected: true,
+              },
+            ]
+          : [],
+        status: 200,
+      });
+    });
+    const dialog = await openSettings(page);
+    const usbSwitch = dialog.getByRole('switch', { name: /temperature sensor/i });
+
+    await usbSwitch.click();
+    await expect(usbSwitch).toBeChecked();
+    await expect(dialog.getByText('1 unsaved change')).toBeVisible();
+    const readsBeforeRefresh = usbReads;
+    serverReportsEnabled = true;
+    await page.evaluate(() => {
+      const afterStaleTime = Date.now() + 31_000;
+      Date.now = () => afterStaleTime;
+      window.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    await expect.poll(() => usbReads).toBeGreaterThan(readsBeforeRefresh);
+    await expect(usbSwitch).toBeChecked();
+    await expect(dialog.getByText('1 unsaved change')).toBeVisible();
+  });
+
+  test('applies configuration without starting an instance that was stopped', async ({ page }) => {
+    const audit: Audit = { writes: [], restarts: [] };
+    await mockInstanceConfiguration(page, audit, false);
+    const dialog = await openSettings(page);
+
+    await dialog.getByRole('button', { name: 'Environment' }).click();
+    await dialog.getByLabel('Value for MODE').fill('staging');
+    await expect(dialog.getByRole('button', { name: 'Apply changes' })).toBeVisible();
+    await dialog.getByRole('button', { name: 'Apply changes' }).click();
+
+    await expect(dialog).toBeHidden();
+    expect(audit.writes).toEqual(['environment:PUT']);
+    expect(audit.restarts).toEqual([]);
+  });
+
+  test('preserves the draft and does not restart after a failed write', async ({ page }) => {
+    const audit: Audit = { writes: [], restarts: [] };
+    await mockInstanceConfiguration(page, audit, true, true);
+    const dialog = await openSettings(page);
+
+    await dialog.getByRole('button', { name: 'Environment' }).click();
+    await dialog.getByLabel('Value for MODE').fill('staging');
+    await dialog.getByRole('button', { name: 'Apply & restart' }).click();
+
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText('Configuration rejected')).toBeVisible();
+    await expect(dialog.getByLabel('Value for MODE')).toHaveValue('staging');
+    expect(audit.writes).toEqual(['environment:PUT']);
+    expect(audit.restarts).toEqual([]);
+  });
+
+  test('makes version updates and downgrades explicit before any operation starts', async ({
+    page,
+  }) => {
+    const audit: Audit = { writes: [], restarts: [] };
+    await mockInstanceConfiguration(page, audit);
+    const dialog = await openSettings(page);
+
+    await dialog.getByRole('button', { name: 'Version' }).click();
+    await expect(dialog.getByText('Current version')).toBeVisible();
+    await expect(dialog.getByText('0.3.0-rc.3', { exact: true })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Done' })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Apply & restart' })).toHaveCount(0);
+
+    const targetVersion = dialog.getByRole('combobox', { name: 'Target version' });
+    await targetVersion.selectOption('0.2.0');
+    await expect(dialog.getByRole('button', { name: 'Downgrade to 0.2.0' })).toBeVisible();
+    await expect(dialog.getByText(/older version/i)).toBeVisible();
+
+    await targetVersion.selectOption('0.4.0');
+    await expect(dialog.getByRole('button', { name: 'Update to 0.4.0' })).toBeVisible();
+    await expect(dialog.getByText(/newer version/i)).toBeVisible();
+  });
+
+  test('reuses a downloaded version when downgrading', async ({ page }) => {
+    const audit: Audit = { writes: [], restarts: [] };
+    const operations: string[] = [];
+    await mockInstanceConfiguration(page, audit);
+    await page.route('**/api/v2/apps', (route) =>
+      route.fulfill({
+        json: [
+          fixtures.installedApp(),
+          fixtures.installedApp({
+            appKey: { name: 'tech.flecs.fence', version: '0.2.0' },
+          }),
+        ],
+        status: 200,
+      }),
+    );
+    await page.route('**/api/v2/apps/install', (route) => {
+      operations.push('install');
+      return route.fulfill({ json: { jobId: 80 }, status: 202 });
+    });
+    await page.route('**/api/v2/instances/00000001', (route) => {
+      if (route.request().method() === 'PATCH') {
+        const body = route.request().postDataJSON() as { to: string };
+        operations.push(`migrate:${body.to}`);
+        return route.fulfill({ json: { jobId: 81 }, status: 202 });
+      }
+      return route.fulfill({ json: fixtures.instance(), status: 200 });
+    });
+    await page.route('**/api/v2/apps/tech.flecs.fence?*', (route) => {
+      const version = new URL(route.request().url()).searchParams.get('version');
+      operations.push(`remove:${version}`);
+      return route.fulfill({ json: { jobId: 82 }, status: 202 });
+    });
+
+    const dialog = await openSettings(page);
+    await dialog.getByRole('button', { name: 'Version' }).click();
+    await dialog.getByRole('combobox', { name: 'Target version' }).selectOption('0.2.0');
+    await dialog.getByRole('button', { name: 'Downgrade to 0.2.0' }).click();
+
+    const progress = page.getByRole('dialog', { name: /downgrade test app to 0.2.0/i });
+    await expect(progress.getByText('Version changed!')).toBeVisible();
+    expect(operations).toEqual(['migrate:0.2.0', 'remove:0.3.0-rc.3']);
+  });
+});

--- a/src/app/components/ConfirmDialog.tsx
+++ b/src/app/components/ConfirmDialog.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useId, useRef } from 'react';
 
 /**
- * Confirm dialog — uses native <dialog> element.
- * Focus trapping, ESC to close, backdrop — all built-in. Zero portal hacking.
+ * Confirm dialog using the native <dialog> element.
+ * Focus trapping, Escape to close, and backdrop behavior are built in.
  */
 const ConfirmDialog = ({
   title,
@@ -11,6 +11,7 @@ const ConfirmDialog = ({
   setOpen,
   onConfirm,
   confirmLabel,
+  cancelLabel,
   confirmDestructive,
 }: {
   title: string;
@@ -19,33 +20,39 @@ const ConfirmDialog = ({
   setOpen: (open: boolean) => void;
   onConfirm: () => void;
   confirmLabel?: string;
+  cancelLabel?: string;
   confirmDestructive?: boolean;
 }) => {
   const ref = useRef<HTMLDialogElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
+  const titleId = useId();
 
   useEffect(() => {
-    if (open) ref.current?.showModal();
-    else ref.current?.close();
+    if (open) {
+      ref.current?.showModal();
+      cancelRef.current?.focus();
+    } else ref.current?.close();
   }, [open]);
 
   return (
     <dialog
       ref={ref}
+      aria-labelledby={titleId}
       onClose={() => setOpen(false)}
-      onClick={(e) => {
-        if (e.target === ref.current) setOpen(false);
-      }}
       className="backdrop:bg-black/60 bg-transparent p-0 m-auto max-w-md w-full open:flex open:items-center open:justify-center"
     >
       <div className="bg-surface-raised rounded-2xl p-6 w-full shadow-2xl border border-border mx-4">
-        <h3 className="text-lg font-semibold text-text-primary mb-2">{title}</h3>
+        <h3 id={titleId} className="text-lg font-semibold text-text-primary mb-2">
+          {title}
+        </h3>
         <div className="text-sm text-text-secondary mb-6">{children}</div>
         <div className="flex justify-end gap-3">
           <button
+            ref={cancelRef}
             className="px-4 py-2 text-sm font-semibold rounded-lg text-text-primary hover:bg-surface-hover transition cursor-pointer"
             onClick={() => setOpen(false)}
           >
-            Cancel
+            {cancelLabel || 'Cancel'}
           </button>
           <button
             className={`px-4 py-2 text-sm font-semibold rounded-lg transition cursor-pointer ${confirmDestructive ? 'bg-error text-white hover:bg-error/80' : 'bg-brand text-white hover:bg-brand-end'}`}
@@ -53,7 +60,6 @@ const ConfirmDialog = ({
               setOpen(false);
               onConfirm();
             }}
-            autoFocus
           >
             {confirmLabel || 'Confirm'}
           </button>

--- a/src/app/components/ContentDialog.tsx
+++ b/src/app/components/ContentDialog.tsx
@@ -1,4 +1,4 @@
-import { createPortal } from 'react-dom';
+import { useEffect, useId, useRef } from 'react';
 
 interface ContentDialogProps {
   title: string;
@@ -9,38 +9,48 @@ interface ContentDialogProps {
   panelClassName?: string;
 }
 
-function ContentDialog({
+type OpenContentDialogProps = Omit<ContentDialogProps, 'open'>;
+
+function OpenContentDialog({
   title,
-  open,
   setOpen,
   actions,
   children,
   panelClassName,
-}: ContentDialogProps) {
-  if (!open) return null;
+}: OpenContentDialogProps) {
+  const ref = useRef<HTMLDialogElement>(null);
+  const titleId = useId();
 
-  return createPortal(
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
-      onClick={() => setOpen(false)}
+  useEffect(() => {
+    ref.current?.showModal();
+  }, []);
+
+  return (
+    <dialog
+      ref={ref}
+      aria-labelledby={titleId}
+      onClose={() => setOpen(false)}
+      className="m-auto w-[min(896px,94vw)] max-w-none overflow-visible bg-transparent p-0 text-text-primary backdrop:bg-black/60"
     >
       <div
         className={
           panelClassName ??
           'bg-surface-raised rounded-2xl max-w-4xl w-full max-h-[90vh] flex flex-col shadow-2xl border border-border'
         }
-        onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-6 py-4 border-b border-border">
-          <h3 className="text-lg font-semibold">{title}</h3>
+        <div className="border-b border-border px-6 py-4">
+          <h3 id={titleId} className="text-lg font-semibold">
+            {title}
+          </h3>
         </div>
-        <div className="flex-1 overflow-auto px-6 py-4 border-b border-border">
+        <div className="flex-1 overflow-auto border-b border-border px-6 py-4">
           {children ?? <p className="text-sm text-muted">No content to display.</p>}
         </div>
-        <div className="px-6 py-3 flex justify-end gap-2">
+        <div className="flex justify-end gap-2 px-6 py-3">
           {actions ?? (
             <button
-              className="px-4 py-2 border border-brand text-brand rounded-lg font-semibold hover:bg-brand/10 transition text-sm"
+              type="button"
+              className="cursor-pointer rounded-lg border border-brand px-4 py-2 text-sm font-semibold text-brand transition hover:bg-brand/10"
               onClick={() => setOpen(false)}
             >
               Close
@@ -48,8 +58,13 @@ function ContentDialog({
           )}
         </div>
       </div>
-    </div>,
-    document.body,
+    </dialog>
   );
 }
+
+function ContentDialog(props: ContentDialogProps) {
+  if (!props.open) return null;
+  return <OpenContentDialog {...props} />;
+}
+
 export default ContentDialog;

--- a/src/app/components/VersionSelector.tsx
+++ b/src/app/components/VersionSelector.tsx
@@ -1,70 +1,56 @@
-import { useState, useRef, useEffect } from 'react';
-import { Sparkles, ChevronDown } from 'lucide-react';
+import { ChevronDown } from 'lucide-react';
 import type { AppVersion } from '@features/apps/types';
 
 interface VersionSelectorProps {
   availableVersions: AppVersion[];
   selectedVersion: AppVersion | undefined;
   setSelectedVersion: (v: AppVersion) => void;
+  currentVersion?: string;
+  label?: string;
 }
 
 export function VersionSelector({
   availableVersions,
   selectedVersion,
   setSelectedVersion,
+  currentVersion,
+  label = 'Version',
 }: VersionSelectorProps) {
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  const hasUpdate = availableVersions.length > 0 && !availableVersions[0]?.installed;
-
-  useEffect(() => {
-    if (!open) return;
-    const handler = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener('mousedown', handler);
-    return () => document.removeEventListener('mousedown', handler);
-  }, [open]);
-
   if (!availableVersions.length) return null;
 
   return (
-    <div className="relative" ref={ref}>
-      <button
-        onClick={() => setOpen(!open)}
-        className="w-full flex items-center justify-between px-3 py-2.5 bg-surface rounded-lg border border-border text-text-primary text-sm hover:border-border-strong transition cursor-pointer"
+    <div className="relative">
+      <select
+        aria-label={label}
+        value={selectedVersion?.version ?? ''}
+        onChange={(event) => {
+          const version = availableVersions.find((item) => item.version === event.target.value);
+          if (version) setSelectedVersion(version);
+        }}
+        className="w-full cursor-pointer appearance-none rounded-lg border border-border bg-surface py-2.5 pl-3 pr-9 text-sm font-medium text-text-primary outline-none transition hover:border-border-strong focus:border-brand focus:ring-2 focus:ring-brand/15"
       >
-        <span>{selectedVersion?.version || 'Select version'}</span>
-        <div className="flex items-center gap-1.5">
-          {selectedVersion?.installed && (
-            <span className="text-[11px] text-muted px-1.5 py-0.5 rounded bg-surface-hover">
-              installed
-            </span>
-          )}
-          {hasUpdate && <Sparkles size={13} className="text-brand" />}
-          <ChevronDown
-            size={15}
-            className={`text-muted transition-transform ${open ? 'rotate-180' : ''}`}
-          />
-        </div>
-      </button>
-      {open && (
-        <div className="absolute z-50 mt-1 w-full rounded-lg bg-surface-raised border border-border shadow-xl max-h-60 overflow-auto">
-          {availableVersions.map((v) => (
-            <button
-              key={v.version}
-              onClick={() => {
-                setSelectedVersion(v);
-                setOpen(false);
-              }}
-              className={`w-full flex items-center justify-between px-3 py-2 text-sm transition cursor-pointer ${v.version === selectedVersion?.version ? 'bg-surface-hover text-text-primary' : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'}`}
-            >
-              <span>{v.version}</span>
-              {v.installed && <span className="text-[11px] text-muted">installed</span>}
-            </button>
-          ))}
-        </div>
-      )}
+        {availableVersions.map((version, index) => {
+          const detail =
+            version.version === currentVersion
+              ? 'Current'
+              : index === 0
+                ? 'Latest'
+                : version.installed
+                  ? 'Downloaded'
+                  : undefined;
+          return (
+            <option key={version.version} value={version.version}>
+              {version.version}
+              {detail ? ` (${detail})` : ''}
+            </option>
+          );
+        })}
+      </select>
+      <ChevronDown
+        aria-hidden="true"
+        size={15}
+        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted"
+      />
     </div>
   );
 }

--- a/src/features/apps/components/InstalledAppRow.tsx
+++ b/src/features/apps/components/InstalledAppRow.tsx
@@ -15,18 +15,17 @@ import {
   RefreshCw,
   Package,
 } from 'lucide-react';
-import type { EnrichedApp, AppVersion } from '@features/apps/types';
+import type { EnrichedApp } from '@features/apps/types';
 import type { AppInstance } from '@generated/core/schemas';
 import AppStatusDot from './AppStatusDot';
-import UpdateButton from '@features/apps/components/actions/UpdateButton';
 import ContentDialog from '@app/components/ContentDialog';
 import ConfirmDialog from '@app/components/ConfirmDialog';
 import { useDeleteAppsApp } from '@generated/core/apps/apps';
 import { useGetManifestsAppNameVersion } from '@generated/core/manifests/manifests';
 import InstanceInfo from './instances/InstanceInfo';
 import InstanceConfigDialog, { type SectionKey } from './instances/InstanceConfigDialog';
+import VersionConfigTab from './instances/tabs/VersionConfigTab';
 import InstanceNameDialog from './InstanceNameDialog';
-import { VersionSelector } from '@app/components/VersionSelector';
 import { createUrl } from '@features/apps/components/actions/EditorButton';
 import { useQuestActions } from '@features/notifications/quests/hooks';
 import { unwrapSuccess } from '@app/api/unwrap';
@@ -60,7 +59,8 @@ export default function InstalledAppRow({ app, instance }: InstalledAppRowProps)
   );
   const manifest = unwrapSuccess(manifestResponse);
   const isInstalling = app.status === 'installing';
-  const canDuplicateApp = manifest?.multiInstance === true;
+  const canDuplicateApp =
+    manifest && 'multiInstance' in manifest ? manifest.multiInstance === true : false;
   const instanceCount = app.instances?.length ?? 0;
   const isInstanceScopedApp = Boolean(instance && (canDuplicateApp || instanceCount > 1));
   const isLastInstanceOfApp = isInstanceScopedApp && instanceCount <= 1;
@@ -76,9 +76,6 @@ export default function InstalledAppRow({ app, instance }: InstalledAppRowProps)
     latestVersion &&
     app.installedVersions &&
     !app.installedVersions.includes(latestVersion.version);
-  const [selectedVersion, setSelectedVersion] = useState<AppVersion>(
-    latestVersion ?? { version: app.appKey?.version ?? '', installed: true },
-  );
   const questProgress = app._quest?.progress;
   const statusLabel = isInstalling
     ? `Installing${questProgress != null ? `... ${questProgress}%` : ''}`
@@ -115,10 +112,7 @@ export default function InstalledAppRow({ app, instance }: InstalledAppRowProps)
   // above the button when there isn't room below, and cap its height as a
   // safety net so a long menu near a screen edge never gets clipped.
   useLayoutEffect(() => {
-    if (!menuAnchor) {
-      setMenuStyle({ visibility: 'hidden' });
-      return;
-    }
+    if (!menuAnchor) return;
     const btn = btnRef.current;
     const menu = menuRef.current;
     if (!btn || !menu) return;
@@ -237,7 +231,6 @@ export default function InstalledAppRow({ app, instance }: InstalledAppRowProps)
     }
   };
 
-  const selectedVersionNotInstalled = !app.installedVersions?.includes(selectedVersion.version);
   const instanceName = instance?.instanceName.trim();
   const instanceDisplayName =
     isInstanceScopedApp && instance ? instanceName || `Instance ${instance.instanceId}` : undefined;
@@ -266,15 +259,16 @@ export default function InstalledAppRow({ app, instance }: InstalledAppRowProps)
               )}
             </span>
             {updateAvailable && (
-              <span
-                className="px-2 py-0.5 rounded-full bg-accent/20 text-accent text-[0.65rem] font-semibold cursor-pointer inline-flex items-center gap-1"
+              <button
+                type="button"
+                className="inline-flex cursor-pointer items-center gap-1 rounded-full bg-accent/20 px-2 py-0.5 text-[0.65rem] font-semibold text-accent"
                 onClick={() => {
                   setSettingsSection('version');
                   setSettingsOpen(true);
                 }}
               >
                 <RefreshCw size={10} /> Update
-              </span>
+              </button>
             )}
           </div>
           <div className="flex items-center gap-1 text-xs text-muted">
@@ -448,34 +442,25 @@ export default function InstalledAppRow({ app, instance }: InstalledAppRowProps)
           >
             <InstanceInfo instance={instance} />
           </ContentDialog>
-          <InstanceConfigDialog
-            instanceId={instance.instanceId}
-            instanceName={instance.instanceName}
-            open={settingsOpen}
-            initialSection={settingsSection}
-            onClose={() => setSettingsOpen(false)}
-            versionSection={
-              versionsArray.length > 0 ? (
-                <div>
-                  <VersionSelector
-                    availableVersions={versionsArray}
-                    selectedVersion={selectedVersion}
-                    setSelectedVersion={setSelectedVersion}
+          {settingsOpen && (
+            <InstanceConfigDialog
+              key={`${instance.instanceId}-${settingsSection ?? 'settings'}`}
+              instanceId={instance.instanceId}
+              instanceName={instance.instanceName}
+              instanceIsRunning={isRunning}
+              initialSection={settingsSection}
+              onClose={() => setSettingsOpen(false)}
+              versionSection={
+                versionsArray.length > 0 ? (
+                  <VersionConfigTab
+                    app={app}
+                    currentVersion={instance.appKey.version}
+                    versions={versionsArray}
                   />
-                  {selectedVersionNotInstalled && (
-                    <div className="mt-4">
-                      <UpdateButton app={app} to={selectedVersion} showSelectedVersion fullWidth />
-                    </div>
-                  )}
-                  {!selectedVersionNotInstalled && (
-                    <p className="text-sm text-muted mt-4 text-center">
-                      {selectedVersion?.version} is already installed.
-                    </p>
-                  )}
-                </div>
-              ) : undefined
-            }
-          />
+                ) : undefined
+              }
+            />
+          )}
         </>
       )}
       <InstanceNameDialog

--- a/src/features/apps/components/InstalledAppsTable.tsx
+++ b/src/features/apps/components/InstalledAppsTable.tsx
@@ -11,7 +11,7 @@ type InstalledAppListRow =
   | { kind: 'instance'; app: EnrichedApp; instance: AppInstance };
 
 function createInstalledAppRows(apps: EnrichedApp[]): InstalledAppListRow[] {
-  return apps.flatMap((app) => {
+  return apps.flatMap<InstalledAppListRow>((app) => {
     const instances = app.instances ?? [];
     if (instances.length === 0) return [{ kind: 'app', app }];
     return instances.map((instance) => ({ kind: 'instance', app, instance }));

--- a/src/features/apps/components/actions/UpdateButton.tsx
+++ b/src/features/apps/components/actions/UpdateButton.tsx
@@ -8,54 +8,56 @@ import MarqueeText from '@app/components/MarqueeText';
 
 interface UpdateButtonProps {
   app: EnrichedApp;
-  from?: AppVersion;
   to: AppVersion;
-  onInstallComplete?: (success: boolean, message: string, error?: string) => void;
   showSelectedVersion?: boolean;
   fullWidth?: boolean;
+  fromVersion?: string;
+  operation?: 'update' | 'downgrade';
 }
 
 export default function UpdateButton({
   app,
-  from,
   to,
-  onInstallComplete,
   showSelectedVersion = false,
   fullWidth,
+  fromVersion,
+  operation = 'update',
 }: UpdateButtonProps): React.ReactElement {
   const [state, setState] = useState<{ updating: boolean; currentQuest: Quest | null }>({
     updating: false,
     currentQuest: null,
   });
   const [updateAppOpen, setUpdateAppOpen] = useState<boolean>(false);
+  const action = operation === 'downgrade' ? 'Downgrade' : 'Update';
   return (
     <React.Fragment>
       <button
-        className={`bg-accent text-white font-semibold hover:bg-accent/80 transition inline-flex items-center gap-2 ${fullWidth ? 'px-4 py-3 rounded-xl text-base w-full justify-center' : 'px-4 py-2 rounded-lg'}`}
+        className={`inline-flex cursor-pointer items-center gap-2 bg-accent font-semibold text-white transition hover:bg-accent/80 disabled:cursor-not-allowed disabled:opacity-50 ${fullWidth ? 'w-full justify-center rounded-xl px-4 py-3 text-base' : 'rounded-lg px-4 py-2'}`}
         onClick={() => setUpdateAppOpen(true)}
         data-testid="update-app-button"
         disabled={state.updating}
       >
         {state.updating ? (
-          <div className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full" />
+          <div className="h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
         ) : (
           <RefreshCw size={18} />
         )}
         {state.updating ? (
-          <MarqueeText text={state.currentQuest?.description || 'Updating'} />
+          <MarqueeText text={state.currentQuest?.description || `${action} in progress`} />
         ) : (
-          `Update${showSelectedVersion ? ` to ${to.version}` : ''}`
+          `${action}${showSelectedVersion ? ` to ${to.version}` : ''}`
         )}
       </button>
       <ContentDialog
         open={updateAppOpen}
         setOpen={setUpdateAppOpen}
-        title={`Update ${app.title} to ${to.version}`}
+        title={`${action} ${app.title} to ${to.version}`}
       >
         <InstallationStepper
           app={app}
           version={to.version}
           update={true}
+          fromVersion={fromVersion}
           onStateChange={(s: InstallerState) =>
             setState({
               updating: s.installing || (s.updating ?? false),

--- a/src/features/apps/components/installation/AppInstaller.tsx
+++ b/src/features/apps/components/installation/AppInstaller.tsx
@@ -1,8 +1,8 @@
 /**
- * App Installer — ONE component for install, update, and sideload.
+ * App Installer - one component for install, update, and sideload.
  * Uses generated orval mutations + quest polling. Zero wrapper hooks.
  *
- * Flow: check activation → mutation → waitForQuest → create instance → start
+ * Flow: check activation, mutate, wait for the quest, then continue.
  */
 import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { RotateCcw, CheckCircle2, AlertCircle } from 'lucide-react';
@@ -60,7 +60,7 @@ export default function AppInstaller({
   const abortRef = useRef<AbortController | null>(null);
   const qc = useQueryClient();
 
-  // Generated hooks — zero wrappers
+  // Generated hooks with no wrapper layer
   const { mutateAsync: installApp } = usePostAppsInstall();
   const { mutateAsync: sideloadApp } = usePostAppsSideload();
   const { mutateAsync: deleteApp } = useDeleteAppsApp();
@@ -69,7 +69,7 @@ export default function AppInstaller({
   const { mutateAsync: startInstance } = usePostInstancesInstanceIdStart();
   const { waitForQuest } = useQuestActions();
 
-  // Activation check — generated hook
+  // Activation check from the generated hook
   const { data: licData } = useGetDeviceLicenseActivationStatus({ query: { staleTime: 60_000 } });
   const activated = unwrapSuccess(licData)?.isValid ?? false;
 
@@ -80,16 +80,19 @@ export default function AppInstaller({
   // finishes (see waitForQuest cleanup path). abortRef stays wired so a
   // future explicit Cancel button can trigger it + DELETE /quests/{id}.
 
-  const questStep = async (jobId: number) => {
-    onStateChange?.({ installing: true });
-    const result = await waitForQuest(jobId, abortRef.current?.signal);
-    if (!questStateFinishedOk(result.state)) {
-      throw new Error(result.result || result.detail || result.description || 'Quest failed');
-    }
-    return result;
-  };
+  const questStep = useCallback(
+    async (jobId: number) => {
+      onStateChange?.({ installing: true });
+      const result = await waitForQuest(jobId, abortRef.current?.signal);
+      if (!questStateFinishedOk(result.state)) {
+        throw new Error(result.result || result.detail || result.description || 'Quest failed');
+      }
+      return result;
+    },
+    [onStateChange, waitForQuest],
+  );
 
-  /** Extract jobId from an orval mutation response. Backends return JobMeta on 202. */
+  /** Extract jobId from an Orval mutation response. Backends return JobMeta on 202. */
   function getJobId<T extends { status: number; data: unknown }>(response: T): number {
     const data = unwrapSuccess(response);
     if (!isJobMeta(data)) throw new Error('No jobId in response');
@@ -136,10 +139,13 @@ export default function AppInstaller({
           throw new Error('Missing app, target version, or source version for update');
         }
         const appName = app.appKey.name;
+        const targetAlreadyInstalled = app.installedVersions?.includes(version) ?? false;
 
-        setMessage('Installing new version...');
-        const r = await installApp({ data: { appKey: { name: appName, version } } });
-        await questStep(getJobId(r));
+        if (!targetAlreadyInstalled) {
+          setMessage('Downloading selected version...');
+          const r = await installApp({ data: { appKey: { name: appName, version } } });
+          await questStep(getJobId(r));
+        }
 
         // Parallelize instance migrations. Cap enforces a defensive bound
         // against runaway manifests (WSTG-BUSL-07); 100 covers any realistic
@@ -165,9 +171,11 @@ export default function AppInstaller({
           );
         }
 
-        setMessage('Removing old version...');
-        const dr = await deleteApp({ app: appName, params: { version: fromVersion } });
-        await questStep(getJobId(dr));
+        if (fromVersion !== version) {
+          setMessage('Removing previous version...');
+          const dr = await deleteApp({ app: appName, params: { version: fromVersion } });
+          await questStep(getJobId(dr));
+        }
       }
 
       setPhase('success');
@@ -175,7 +183,7 @@ export default function AppInstaller({
         mode === 'install'
           ? 'App installed!'
           : mode === 'update'
-            ? 'App updated!'
+            ? 'Version changed!'
             : 'App sideloaded!',
       );
       qc.invalidateQueries();
@@ -195,12 +203,15 @@ export default function AppInstaller({
     patchInstance,
     createInstance,
     startInstance,
+    questStep,
     qc,
   ]);
 
   // Auto-advance past activation when device is activated
   useEffect(() => {
-    if (activated && phase === 'activation') runInstall();
+    if (!activated || phase !== 'activation') return;
+    const timeout = window.setTimeout(() => void runInstall(), 0);
+    return () => window.clearTimeout(timeout);
   }, [activated, phase, runInstall]);
 
   // Phase: Activation check

--- a/src/features/apps/components/installation/InstallationStepper.tsx
+++ b/src/features/apps/components/installation/InstallationStepper.tsx
@@ -7,6 +7,7 @@ interface InstallationStepperProps {
   version?: string;
   sideload?: boolean;
   update?: boolean;
+  fromVersion?: string;
   onStateChange?: (state: InstallerState) => void;
 }
 
@@ -16,6 +17,7 @@ export default function InstallationStepper({
   version,
   sideload,
   update,
+  fromVersion,
   onStateChange,
 }: InstallationStepperProps) {
   const mode = sideload ? 'sideload' : update ? 'update' : 'install';
@@ -25,7 +27,9 @@ export default function InstallationStepper({
       app={app}
       manifest={manifest}
       version={version || app?.appKey?.version}
-      fromVersion={update ? app?.installedVersions?.[0] : undefined}
+      fromVersion={
+        update ? (fromVersion ?? app?.appKey.version ?? app?.installedVersions?.[0]) : undefined
+      }
       onStateChange={onStateChange}
     />
   );

--- a/src/features/apps/components/instances/InstanceConfigDialog.tsx
+++ b/src/features/apps/components/instances/InstanceConfigDialog.tsx
@@ -1,167 +1,465 @@
-import { createPortal } from 'react-dom';
-import React, { useEffect, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  AlertCircle,
+  Cable,
+  ChevronDown,
+  ChevronUp,
+  ExternalLink,
+  GitBranch,
+  LoaderCircle,
+  Network,
+  Usb,
+  Variable,
+  X,
+} from 'lucide-react';
 import { toast } from 'sonner';
-import { X, Usb, Network, Cable, Variable, ExternalLink, GitBranch } from 'lucide-react';
 import { getErrorMessage } from '@app/api/fetch-error';
-import UsbConfigTab from './tabs/UsbConfigTab';
+import { unwrapSuccess } from '@app/api/unwrap';
+import ConfirmDialog from '@app/components/ConfirmDialog';
+import {
+  getGetInstancesQueryKey,
+  postInstancesInstanceIdStart,
+  postInstancesInstanceIdStop,
+} from '@generated/core/instances/instances';
+import type { Quest } from '@generated/core/schemas';
+import { useQuestActions } from '@features/notifications/quests/hooks';
+import { isFinishedOk } from '@features/notifications/quests/QuestItem';
+import EditorConfigTab from './tabs/EditorConfigTab';
+import EnvironmentConfigTab from './tabs/EnvironmentConfigTab';
 import NetworkConfigTab from './tabs/NetworkConfigTab';
 import PortsConfigTab from './tabs/PortsConfigTab';
-import EnvironmentConfigTab from './tabs/EnvironmentConfigTab';
-import EditorConfigTab from './tabs/EditorConfigTab';
-import {
-  postInstancesInstanceIdStop,
-  postInstancesInstanceIdStart,
-} from '@generated/core/instances/instances';
+import UsbConfigTab from './tabs/UsbConfigTab';
+import { useInstanceConfigDraft, type DraftSection } from './useInstanceConfigDraft';
 
 interface InstanceConfigDialogProps {
   instanceId: string;
   instanceName: string;
-  open: boolean;
+  instanceIsRunning: boolean;
   onClose: () => void;
-  versionSection?: React.ReactNode;
+  versionSection?: ReactNode;
   initialSection?: SectionKey;
 }
 
-const sections = [
-  { key: 'usb', label: 'USB Devices', icon: Usb },
-  { key: 'network', label: 'Network', icon: Network },
-  { key: 'ports', label: 'Ports', icon: Cable },
-  { key: 'env', label: 'Environment', icon: Variable },
-  { key: 'editors', label: 'Editors', icon: ExternalLink },
+type ConfigSectionKey = 'usb' | 'network' | 'ports' | 'env' | 'editors';
+type ConfigSection = {
+  key: ConfigSectionKey;
+  label: string;
+  description: string;
+  icon: typeof Usb;
+  staged?: DraftSection;
+};
+
+const sections: readonly ConfigSection[] = [
+  {
+    key: 'usb',
+    label: 'USB Devices',
+    description: 'Choose which host devices this instance can access.',
+    icon: Usb,
+    staged: 'usb',
+  },
+  {
+    key: 'network',
+    label: 'Network',
+    description: 'Connect this instance to a host network interface. Changes apply immediately.',
+    icon: Network,
+  },
+  {
+    key: 'ports',
+    label: 'Ports',
+    description: 'Map host traffic to ports inside this instance.',
+    icon: Cable,
+    staged: 'ports',
+  },
+  {
+    key: 'env',
+    label: 'Environment',
+    description: 'Set values the app receives when it starts.',
+    icon: Variable,
+    staged: 'env',
+  },
+  {
+    key: 'editors',
+    label: 'Editors',
+    description: 'Manage editor addresses and path prefixes. Changes apply immediately.',
+    icon: ExternalLink,
+  },
 ] as const;
 
-export type SectionKey = (typeof sections)[number]['key'] | 'version';
+export type SectionKey = ConfigSectionKey | 'version';
+type ApplyState = 'idle' | 'saving' | 'stopping' | 'starting';
+type RestartStep = 'stop' | 'start' | null;
 
-const InstanceConfigDialog: React.FC<InstanceConfigDialogProps> = ({
+const sectionLabels: Record<DraftSection, string> = {
+  usb: 'USB Devices',
+  ports: 'Ports',
+  env: 'Environment',
+};
+
+const InstanceConfigDialog = ({
   instanceId,
   instanceName,
-  open,
+  instanceIsRunning,
   onClose,
   versionSection,
   initialSection,
-}) => {
-  const defaultSection: SectionKey = versionSection ? 'version' : 'usb';
-  const [activeSection, setActiveSection] = useState<SectionKey>(initialSection ?? defaultSection);
-  const [hasChanges, setHasChanges] = useState(false);
+}: InstanceConfigDialogProps) => {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const applyLockRef = useRef(false);
+  const queryClient = useQueryClient();
+  const { waitForQuest } = useQuestActions();
+  const config = useInstanceConfigDraft(instanceId);
+  const [activeSection, setActiveSection] = useState<SectionKey>(initialSection ?? 'usb');
+  const [discardOpen, setDiscardOpen] = useState(false);
+  const [showReview, setShowReview] = useState(false);
+  const [applyState, setApplyState] = useState<ApplyState>('idle');
+  const [restartStep, setRestartStep] = useState<RestartStep>(null);
+  const [actionError, setActionError] = useState<string>();
+  const isBusy = applyState !== 'idle';
+  const hasChanges = config.dirtySections.length > 0;
+  const activeMetadata = sections.find(({ key }) => key === activeSection);
+  const showConfigActions =
+    Boolean(activeMetadata?.staged) || hasChanges || Boolean(restartStep) || Boolean(actionError);
 
-  // The dialog stays mounted while closed, so activeSection would otherwise
-  // retain the last-visited tab. Reset to the requested section each time it
-  // opens so e.g. "Update" always lands on the Version tab.
   useEffect(() => {
-    if (open) setActiveSection(initialSection ?? defaultSection);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, initialSection]);
+    const dialog = dialogRef.current;
+    if (!dialog?.open) dialog?.showModal();
+  }, []);
 
-  const handleClose = () => {
-    const needsRestart = hasChanges;
-    setHasChanges(false);
-    // Close immediately. The restart (stop → start) is an instance reboot that can
-    // take several seconds; awaiting it before onClose() left the dialog open and
-    // unresponsive (the X also runs handleClose, so it appeared frozen) until the
-    // instance came back. Run it in the background and report the outcome via toast.
+  const requestClose = () => {
+    if (isBusy) return;
+    if (hasChanges) {
+      setDiscardOpen(true);
+      return;
+    }
     onClose();
-    if (needsRestart) {
-      void (async () => {
-        const toastId = toast.loading(`Restarting ${instanceName}…`);
-        try {
-          await postInstancesInstanceIdStop(instanceId);
-          await postInstancesInstanceIdStart(instanceId);
-          toast.success(`${instanceName} restarted`, { id: toastId });
-        } catch (error) {
-          toast.error(getErrorMessage(error), { id: toastId });
-        }
-      })();
+  };
+
+  const waitForLifecycle = async (
+    response: Awaited<
+      ReturnType<typeof postInstancesInstanceIdStop | typeof postInstancesInstanceIdStart>
+    >,
+  ) => {
+    const jobId = unwrapSuccess(response)?.jobId;
+    if (!jobId) throw new Error('The device did not return a restart job.');
+    const result: Quest = await waitForQuest(jobId);
+    if (!isFinishedOk(result.state)) {
+      throw new Error(result.detail || result.description || 'The restart could not be completed.');
     }
   };
 
-  if (!open) return null;
+  const applyChanges = async () => {
+    if ((!hasChanges && !restartStep) || config.validationError || isBusy || applyLockRef.current)
+      return;
+    applyLockRef.current = true;
+    setActionError(undefined);
 
-  return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div
-        className="bg-surface-raised rounded-2xl overflow-hidden flex shadow-2xl border border-border w-full max-w-4xl"
-        style={{ height: '70vh', maxHeight: 640 }}
-      >
-        {/* Sidebar */}
-        <div className="w-[220px] shrink-0 border-r border-border flex flex-col bg-surface-subtle">
-          <div className="px-4 py-4">
-            <span className="text-sm font-bold truncate block">{instanceName}</span>
-            <span className="text-xs text-muted">Settings</span>
-          </div>
-          <hr className="border-border" />
-          <nav className="flex-1 py-1">
-            {versionSection && (
-              <button
-                onClick={() => setActiveSection('version')}
-                className={`flex items-center gap-3 w-52 mx-1 px-3 py-3 rounded-lg text-sm transition ${activeSection === 'version' ? 'bg-surface-hover font-medium' : 'hover:bg-surface-hover'}`}
-              >
-                <GitBranch size={16} /> Version
-              </button>
-            )}
-            {sections.map(({ key, label, icon: Icon }) => (
-              <button
-                key={key}
-                onClick={() => setActiveSection(key)}
-                className={`flex items-center gap-3 w-52 mx-1 px-3 py-3 rounded-lg text-sm transition ${activeSection === key ? 'bg-surface-hover font-medium' : 'hover:bg-surface-hover'}`}
-              >
-                <Icon size={16} /> {label}
-              </button>
-            ))}
-          </nav>
-          <hr className="border-border" />
-          <div className="p-3">
-            <button
-              onClick={handleClose}
-              className={`w-full px-4 py-2 rounded-lg font-semibold text-sm transition ${hasChanges ? 'bg-brand text-white hover:bg-brand-end' : 'border border-border hover:bg-surface-hover'}`}
-            >
-              {hasChanges ? 'Save & Restart' : 'Close'}
-            </button>
-          </div>
+    try {
+      if (hasChanges) {
+        setApplyState('saving');
+        await config.apply();
+      }
+
+      if (instanceIsRunning) {
+        const nextStep = restartStep ?? 'stop';
+        if (nextStep === 'stop') {
+          setRestartStep('stop');
+          setApplyState('stopping');
+          await waitForLifecycle(await postInstancesInstanceIdStop(instanceId));
+          setRestartStep('start');
+        }
+
+        setApplyState('starting');
+        await waitForLifecycle(await postInstancesInstanceIdStart(instanceId));
+        setRestartStep(null);
+      }
+
+      await queryClient.invalidateQueries({ queryKey: getGetInstancesQueryKey() });
+      toast.success(
+        instanceIsRunning
+          ? `${instanceName} settings applied and instance restarting`
+          : `${instanceName} settings applied`,
+      );
+      onClose();
+    } catch (error) {
+      setActionError(getErrorMessage(error));
+    } finally {
+      applyLockRef.current = false;
+      setApplyState('idle');
+    }
+  };
+
+  const buttonLabel =
+    applyState === 'saving'
+      ? 'Applying...'
+      : applyState === 'stopping'
+        ? 'Stopping...'
+        : applyState === 'starting'
+          ? 'Starting...'
+          : restartStep === 'start'
+            ? 'Start instance'
+            : restartStep
+              ? 'Restart now'
+              : instanceIsRunning
+                ? 'Apply & restart'
+                : 'Apply changes';
+
+  const renderSection = () => {
+    if (activeSection === 'version') return versionSection;
+    if (activeSection === 'network') return <NetworkConfigTab instanceId={instanceId} />;
+    if (activeSection === 'editors') return <EditorConfigTab instanceId={instanceId} />;
+
+    if (config.loading) {
+      return (
+        <div className="flex min-h-64 items-center justify-center" aria-label="Loading settings">
+          <LoaderCircle className="animate-spin text-brand" size={24} />
         </div>
-        {/* Content */}
-        <div className="flex-1 overflow-auto relative">
+      );
+    }
+
+    if (config.loadError || !config.draft) {
+      return (
+        <div className="flex min-h-64 flex-col items-center justify-center rounded-2xl border border-border bg-surface-subtle px-6 text-center">
+          <AlertCircle className="text-error" size={24} />
+          <p className="mt-3 text-sm font-semibold">Settings could not be loaded</p>
+          <p className="mt-1 max-w-sm text-xs text-muted">{getErrorMessage(config.loadError)}</p>
           <button
-            onClick={handleClose}
-            className="absolute right-3 top-3 z-10 p-1.5 rounded-lg bg-surface-hover hover:bg-surface-hover transition"
+            type="button"
+            onClick={() => void config.reload()}
+            className="mt-4 rounded-lg px-3 py-2 text-sm font-semibold text-brand transition hover:bg-brand/10"
           >
-            <X size={16} />
+            Try again
           </button>
-          <div className="p-6">
-            <h6 className="text-base font-bold mb-1">
-              {activeSection === 'version'
-                ? 'Version'
-                : sections.find((s) => s.key === activeSection)?.label}
-            </h6>
-            <p className="text-sm text-muted mb-4">
-              {activeSection === 'version' && 'Change or update the app version.'}
-              {activeSection === 'usb' && 'Configure USB device passthrough.'}
-              {activeSection === 'network' && 'Configure network interfaces.'}
-              {activeSection === 'ports' && 'Configure port mappings.'}
-              {activeSection === 'env' && 'Configure environment variables.'}
-              {activeSection === 'editors' && 'Configure editor URLs and reverse proxy.'}
-            </p>
-            <hr className="border-border mb-4" />
-            {activeSection === 'version' && versionSection}
-            {activeSection === 'usb' && (
-              <UsbConfigTab instanceId={instanceId} onChange={setHasChanges} />
-            )}
-            {activeSection === 'network' && (
-              <NetworkConfigTab instanceId={instanceId} onChange={setHasChanges} />
-            )}
-            {activeSection === 'ports' && (
-              <PortsConfigTab instanceId={instanceId} onChange={setHasChanges} />
-            )}
-            {activeSection === 'env' && (
-              <EnvironmentConfigTab instanceId={instanceId} onChange={setHasChanges} />
-            )}
-            {activeSection === 'editors' && (
-              <EditorConfigTab instanceId={instanceId} onChange={setHasChanges} />
-            )}
-          </div>
         </div>
-      </div>
-    </div>,
-    document.body,
+      );
+    }
+
+    if (activeSection === 'usb') {
+      return <UsbConfigTab devices={config.draft.usb} onToggle={config.toggleUsb} />;
+    }
+    if (activeSection === 'ports') {
+      return <PortsConfigTab rows={config.draft.ports} onChange={config.updatePorts} />;
+    }
+    if (activeSection === 'env') {
+      return (
+        <EnvironmentConfigTab rows={config.draft.environment} onChange={config.updateEnvironment} />
+      );
+    }
+    return null;
+  };
+
+  return (
+    <>
+      <dialog
+        ref={dialogRef}
+        aria-labelledby="instance-settings-title"
+        aria-describedby="instance-settings-description"
+        onCancel={(event) => {
+          event.preventDefault();
+          requestClose();
+        }}
+        onClose={() => {
+          onClose();
+        }}
+        className="m-auto h-[min(720px,92vh)] w-[min(1040px,94vw)] max-w-none overflow-hidden rounded-2xl border border-border bg-surface-raised p-0 text-text-primary shadow-2xl backdrop:bg-black/60"
+      >
+        <div className="flex h-full min-h-0 flex-col">
+          <header className="flex h-16 shrink-0 items-center justify-between border-b border-border px-5">
+            <div className="min-w-0">
+              <h2 id="instance-settings-title" className="truncate text-base font-semibold">
+                Instance settings
+              </h2>
+              <p className="truncate text-xs text-muted">{instanceName}</p>
+            </div>
+            <button
+              type="button"
+              aria-label="Close instance settings"
+              title="Close"
+              disabled={isBusy}
+              onClick={requestClose}
+              className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted transition hover:bg-surface-hover hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:opacity-40"
+            >
+              <X size={18} />
+            </button>
+          </header>
+
+          <div
+            className={`flex min-h-0 flex-1 transition-opacity ${isBusy ? 'opacity-70' : ''}`}
+            inert={isBusy}
+            aria-busy={isBusy}
+          >
+            <aside className="w-[224px] shrink-0 border-r border-border bg-surface-subtle p-3">
+              <nav aria-label="Instance settings sections">
+                <p className="px-2 pb-2 pt-1 text-[11px] font-semibold uppercase tracking-wider text-muted">
+                  Configuration
+                </p>
+                <div className="space-y-1">
+                  {versionSection && (
+                    <button
+                      type="button"
+                      aria-current={activeSection === 'version' ? 'page' : undefined}
+                      onClick={() => setActiveSection('version')}
+                      className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition ${
+                        activeSection === 'version'
+                          ? 'bg-surface-raised font-semibold text-text-primary shadow-sm ring-1 ring-border'
+                          : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+                      }`}
+                    >
+                      <GitBranch
+                        size={16}
+                        className={activeSection === 'version' ? 'text-brand' : 'text-muted'}
+                      />
+                      <span className="flex-1">Version</span>
+                    </button>
+                  )}
+                  {sections.map(({ key, label, icon: Icon, staged }) => {
+                    const active = activeSection === key;
+                    const dirty = staged && config.dirtySections.includes(staged);
+                    return (
+                      <button
+                        type="button"
+                        key={key}
+                        aria-current={active ? 'page' : undefined}
+                        onClick={() => setActiveSection(key)}
+                        className={`flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-left text-sm transition ${
+                          active
+                            ? 'bg-surface-raised font-semibold text-text-primary shadow-sm ring-1 ring-border'
+                            : 'text-text-secondary hover:bg-surface-hover hover:text-text-primary'
+                        }`}
+                      >
+                        <Icon size={16} className={active ? 'text-brand' : 'text-muted'} />
+                        <span className="min-w-0 flex-1 truncate">{label}</span>
+                        {dirty && (
+                          <span
+                            className="h-2 w-2 rounded-full bg-brand"
+                            title="Unsaved changes"
+                            aria-label="Unsaved changes"
+                          />
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+              </nav>
+            </aside>
+
+            <main className="min-w-0 flex-1 overflow-auto">
+              <div className="mx-auto max-w-3xl px-7 py-6">
+                <div className="mb-6">
+                  <h3 className="text-lg font-semibold">
+                    {activeSection === 'version' ? 'Version' : activeMetadata?.label}
+                  </h3>
+                  <p id="instance-settings-description" className="mt-1 text-sm text-muted">
+                    {activeSection === 'version'
+                      ? 'Choose the version this app and its instances use.'
+                      : activeMetadata?.description}
+                  </p>
+                </div>
+                {renderSection()}
+              </div>
+            </main>
+          </div>
+
+          <footer className="shrink-0 border-t border-border bg-surface-raised">
+            {showReview && hasChanges && (
+              <div className="flex flex-wrap items-center gap-2 border-b border-border bg-surface-subtle px-5 py-3">
+                <span className="mr-1 text-xs font-medium text-muted">Will update:</span>
+                {config.dirtySections.map((section) => (
+                  <span
+                    key={section}
+                    className="rounded-full border border-border bg-surface-raised px-2.5 py-1 text-xs font-medium"
+                  >
+                    {sectionLabels[section]}
+                  </span>
+                ))}
+              </div>
+            )}
+            {showConfigActions ? (
+              <div className="flex min-h-18 items-center gap-4 px-5 py-3">
+                <div className="min-w-0 flex-1" aria-live="polite">
+                  {actionError ? (
+                    <div className="flex items-center gap-2 text-sm text-error">
+                      <AlertCircle size={16} className="shrink-0" />
+                      <span className="truncate">{actionError}</span>
+                    </div>
+                  ) : config.validationError ? (
+                    <div className="flex items-center gap-2 text-sm text-warning">
+                      <AlertCircle size={16} className="shrink-0" />
+                      <span className="truncate">{config.validationError}</span>
+                    </div>
+                  ) : restartStep ? (
+                    <p className="text-sm font-medium text-warning">
+                      Changes saved. Restart required.
+                    </p>
+                  ) : hasChanges ? (
+                    <button
+                      type="button"
+                      onClick={() => setShowReview((value) => !value)}
+                      className="inline-flex items-center gap-1.5 rounded-lg px-2 py-1 text-sm font-medium text-text-primary transition hover:bg-surface-hover"
+                      aria-expanded={showReview}
+                    >
+                      {config.dirtySections.length}{' '}
+                      {config.dirtySections.length === 1 ? 'unsaved change' : 'unsaved changes'}
+                      {showReview ? <ChevronUp size={15} /> : <ChevronDown size={15} />}
+                    </button>
+                  ) : (
+                    <p className="text-sm text-muted">No pending changes</p>
+                  )}
+                </div>
+                <button
+                  type="button"
+                  disabled={isBusy}
+                  onClick={requestClose}
+                  className="rounded-lg px-4 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand disabled:opacity-40"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={
+                    (!hasChanges && !restartStep) ||
+                    Boolean(config.validationError) ||
+                    config.loading ||
+                    isBusy
+                  }
+                  onClick={() => void applyChanges()}
+                  className="inline-flex min-w-34 items-center justify-center gap-2 rounded-lg bg-brand px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-brand-end focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface-raised disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  {isBusy && <LoaderCircle size={15} className="animate-spin" />}
+                  {buttonLabel}
+                </button>
+              </div>
+            ) : (
+              <div className="flex min-h-18 items-center justify-end px-5 py-3">
+                <button
+                  type="button"
+                  onClick={requestClose}
+                  className="rounded-lg px-4 py-2 text-sm font-semibold text-text-primary transition hover:bg-surface-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+                >
+                  Done
+                </button>
+              </div>
+            )}
+          </footer>
+        </div>
+      </dialog>
+
+      <ConfirmDialog
+        title="Discard changes?"
+        open={discardOpen}
+        setOpen={setDiscardOpen}
+        cancelLabel="Keep editing"
+        confirmLabel="Discard changes"
+        confirmDestructive
+        onConfirm={() => {
+          config.reset();
+          onClose();
+        }}
+      >
+        Your unsaved instance settings will be lost.
+      </ConfirmDialog>
+    </>
   );
 };
+
 export default InstanceConfigDialog;

--- a/src/features/apps/components/instances/tabs/EditorConfigTab.tsx
+++ b/src/features/apps/components/instances/tabs/EditorConfigTab.tsx
@@ -5,10 +5,9 @@ import EditorConfigCard from './EditorConfigCard';
 
 interface EditorConfigTabProps {
   instanceId: string;
-  onChange: (hasChanges: boolean) => void;
 }
 
-const EditorConfigTab: React.FC<EditorConfigTabProps> = ({ instanceId, onChange }) => {
+const EditorConfigTab: React.FC<EditorConfigTabProps> = ({ instanceId }) => {
   const { data: editorsResponse, isLoading } = useGetInstancesInstanceIdConfigEditors(instanceId);
   const editors: InstanceEditor[] = (editorsResponse?.data as InstanceEditor[]) ?? [];
 

--- a/src/features/apps/components/instances/tabs/EnvironmentConfigTab.test.tsx
+++ b/src/features/apps/components/instances/tabs/EnvironmentConfigTab.test.tsx
@@ -1,83 +1,39 @@
-/**
- * Regression test for commit 6f77811 — row identity survives deletion.
- *
- * Pre-fix, EnvironmentConfigTab keyed its rows by array index, so deleting
- * row 0 caused React to reuse the mounted input DOM for row 1 — user saw
- * row 0's typed values appear in row 1. The stable `_rowId` (crypto.randomUUID)
- * fixes this by keying on row identity instead.
- *
- * This assertion can't be done cleanly in Playwright (sensitive to TanStack
- * background refetches under parallel load). React Testing Library is the
- * right tool for component-state-identity invariants.
- */
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import EnvironmentConfigTab from './EnvironmentConfigTab';
+import type { EnvironmentDraft } from '../useInstanceConfigDraft';
 
-// Mock the orval-generated hooks used by the component — no network in unit tests.
-// STABLE references matter: the component's useEffect dep is [envResponse]; if
-// we returned a fresh object per call, the effect would re-fire every render
-// and setEnvVars/setSavedSnapshot would loop to OOM.
-vi.mock('@generated/core/instances/instances', () => {
-  const stableEnvResponse = { data: [] as unknown[], status: 200 };
-  return {
-    useGetInstancesInstanceIdConfigEnvironment: () => ({
-      data: stableEnvResponse,
-      isLoading: false,
-    }),
-    usePutInstancesInstanceIdConfigEnvironment: () => ({ mutateAsync: vi.fn() }),
-    useDeleteInstancesInstanceIdConfigEnvironmentVariableName: () => ({ mutateAsync: vi.fn() }),
-  };
-});
+const Harness = () => {
+  const [rows, setRows] = useState<EnvironmentDraft[]>([]);
+  return <EnvironmentConfigTab rows={rows} onChange={(update) => setRows(update)} />;
+};
 
-function renderWithClient(ui: React.ReactElement) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
-}
+describe('EnvironmentConfigTab row identity', () => {
+  it('preserves the second row values when the first row is deleted', async () => {
+    render(<Harness />);
 
-describe('EnvironmentConfigTab — row identity', () => {
-  beforeEach(() => {
-    // crypto.randomUUID is present in node 20 jsdom but let's be explicit.
-    if (!globalThis.crypto?.randomUUID) {
-      globalThis.crypto = { randomUUID: () => Math.random().toString(36).slice(2) } as Crypto;
-    }
-  });
+    const addButton = screen.getByRole('button', { name: /add variable/i });
+    fireEvent.click(addButton);
 
-  it('deleting row 0 preserves row 1 inputs (no identity bleed)', async () => {
-    const onChange = vi.fn();
-    renderWithClient(<EnvironmentConfigTab instanceId="42" onChange={onChange} />);
+    let nameInputs = screen.getAllByPlaceholderText('VARIABLE_NAME');
+    let valueInputs = screen.getAllByPlaceholderText('value');
+    fireEvent.change(nameInputs[0], { target: { value: 'A' } });
+    fireEvent.change(valueInputs[0], { target: { value: '1' } });
 
-    // Initial state has no rows and an empty-state "Add" button.
-    const addBtn = screen.getByRole('button', { name: /add environment variable/i });
-    fireEvent.click(addBtn);
+    fireEvent.click(screen.getByRole('button', { name: /add variable/i }));
+    nameInputs = screen.getAllByPlaceholderText('VARIABLE_NAME');
+    valueInputs = screen.getAllByPlaceholderText('value');
+    fireEvent.change(nameInputs[1], { target: { value: 'B' } });
+    fireEvent.change(valueInputs[1], { target: { value: '2' } });
 
-    // First row now rendered — fill A=1.
-    const names1 = screen.getAllByPlaceholderText('VARIABLE_NAME');
-    const values1 = screen.getAllByPlaceholderText('value');
-    expect(names1).toHaveLength(1);
-    fireEvent.change(names1[0], { target: { value: 'A' } });
-    fireEvent.change(values1[0], { target: { value: '1' } });
+    fireEvent.click(screen.getAllByRole('button', { name: /delete environment variable/i })[0]);
 
-    // Second add — fill B=2.
-    fireEvent.click(screen.getByRole('button', { name: /add environment variable/i }));
-    const names2 = screen.getAllByPlaceholderText('VARIABLE_NAME');
-    const values2 = screen.getAllByPlaceholderText('value');
-    expect(names2).toHaveLength(2);
-    fireEvent.change(names2[1], { target: { value: 'B' } });
-    fireEvent.change(values2[1], { target: { value: '2' } });
-
-    // Delete row 0.
-    const deleteButtons = screen.getAllByRole('button', { name: /delete environment variable/i });
-    fireEvent.click(deleteButtons[0]);
-
-    // Remaining row must be B=2 — the regression case would show A=1.
     await waitFor(() => {
-      const namesAfter = screen.getAllByPlaceholderText('VARIABLE_NAME');
-      expect(namesAfter).toHaveLength(1);
-      expect((namesAfter[0] as HTMLInputElement).value).toBe('B');
+      const remaining = screen.getAllByPlaceholderText('VARIABLE_NAME');
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0]).toHaveValue('B');
     });
-    const valuesAfter = screen.getAllByPlaceholderText('value');
-    expect((valuesAfter[0] as HTMLInputElement).value).toBe('2');
+    expect(screen.getByPlaceholderText('value')).toHaveValue('2');
   });
 });

--- a/src/features/apps/components/instances/tabs/EnvironmentConfigTab.tsx
+++ b/src/features/apps/components/instances/tabs/EnvironmentConfigTab.tsx
@@ -1,172 +1,71 @@
-import React, { useEffect, useState, useCallback } from 'react';
-import { toast } from 'sonner';
-import { Plus, Save } from 'lucide-react';
-import { InstanceEnvironmentVariable } from '@generated/core/schemas';
-import {
-  useGetInstancesInstanceIdConfigEnvironment,
-  usePutInstancesInstanceIdConfigEnvironment,
-  useDeleteInstancesInstanceIdConfigEnvironmentVariableName,
-} from '@generated/core/instances/instances';
+import { Plus } from 'lucide-react';
+import type { EnvironmentDraft } from '../useInstanceConfigDraft';
 import EnvironmentVariableCard from './EnvironmentVariableCard';
 
 interface EnvironmentConfigTabProps {
-  instanceId: string;
-  onChange: (hasChanges: boolean) => void;
+  rows: EnvironmentDraft[];
+  onChange: (update: (rows: EnvironmentDraft[]) => EnvironmentDraft[]) => void;
 }
 
-// Client-side row identity — stable across edits so React reconciliation keeps input focus
-// on the correct row even after additions/deletions. Stripped before PUT.
-type EnvRow = InstanceEnvironmentVariable & { _rowId: string };
+const EnvironmentConfigTab = ({ rows, onChange }: EnvironmentConfigTabProps) => {
+  const addVariable = () =>
+    onChange((current) => [...current, { name: '', value: '', _rowId: crypto.randomUUID() }]);
 
-const EnvironmentConfigTab: React.FC<EnvironmentConfigTabProps> = ({ instanceId, onChange }) => {
-  const [envVars, setEnvVars] = useState<EnvRow[]>([]);
-  const [savedSnapshot, setSavedSnapshot] = useState<InstanceEnvironmentVariable[]>([]);
-  const [newIndices, setNewIndices] = useState<Set<number>>(new Set());
-  const [modifiedIndices, setModifiedIndices] = useState<Set<number>>(new Set());
-  const { data: envResponse, isLoading } = useGetInstancesInstanceIdConfigEnvironment(instanceId);
-  const { mutateAsync: putEnvironment } = usePutInstancesInstanceIdConfigEnvironment();
-  const { mutateAsync: deleteVariable } =
-    useDeleteInstancesInstanceIdConfigEnvironmentVariableName();
-  const hasChanges = newIndices.size > 0 || modifiedIndices.size > 0;
-
-  useEffect(() => {
-    if (envResponse?.data) {
-      const d = envResponse.data as InstanceEnvironmentVariable[];
-      if (Array.isArray(d)) {
-        setEnvVars(d.map((e) => ({ ...e, _rowId: crypto.randomUUID() })));
-        setSavedSnapshot(d.map((e) => ({ ...e })));
-        setNewIndices(new Set());
-        setModifiedIndices(new Set());
-      }
-    }
-  }, [envResponse]);
-  useEffect(() => {
-    onChange(hasChanges);
-  }, [hasChanges]);
-
-  const handleAdd = () => {
-    setEnvVars((prev) => {
-      const next: EnvRow[] = [...prev, { name: '', value: '', _rowId: crypto.randomUUID() }];
-      setNewIndices((s) => new Set(s).add(next.length - 1));
-      return next;
-    });
-  };
-  const handleChange = useCallback((index: number, key: string, value: string) => {
-    setEnvVars((prev) => prev.map((env, i) => (i === index ? { ...env, [key]: value } : env)));
-    setModifiedIndices((prev) => {
-      const next = new Set(prev);
-      next.add(index);
-      return next;
-    });
-  }, []);
-
-  const reindex = (prev: Set<number>, index: number) => {
-    const next = new Set<number>();
-    prev.forEach((i) => {
-      if (i < index) next.add(i);
-      else if (i > index) next.add(i - 1);
-    });
-    return next;
-  };
-
-  const handleDelete = async (index: number) => {
-    const envVar = envVars[index];
-    if (newIndices.has(index)) {
-      setEnvVars((prev) => prev.filter((_, i) => i !== index));
-      setNewIndices((prev) => reindex(prev, index));
-      setModifiedIndices((prev) => reindex(prev, index));
-      return;
-    }
-    if (envVar.name) {
-      try {
-        await deleteVariable({ instanceId, variableName: envVar.name });
-        onChange(true);
-        setEnvVars((prev) => prev.filter((_, i) => i !== index));
-        setNewIndices((prev) => reindex(prev, index));
-        setModifiedIndices((prev) => reindex(prev, index));
-        setSavedSnapshot((prev) => prev.filter((_, i) => i !== index));
-        toast.success(`Deleted "${envVar.name}"`);
-      } catch {
-        toast.error('Failed to delete environment variable!');
-      }
-    }
-  };
-
-  const handleSaveAll = async () => {
-    try {
-      const variables = envVars
-        .filter(({ name }) => name)
-        .map(({ name, value }) => ({ name, value }));
-      await putEnvironment({ instanceId, data: variables });
-      onChange(true);
-      setSavedSnapshot(variables.map((e) => ({ ...e })));
-      setNewIndices(new Set());
-      setModifiedIndices(new Set());
-      toast.success(`Saved ${variables.length} variable${variables.length !== 1 ? 's' : ''}`);
-    } catch {
-      toast.error('Failed to save environment variables!');
-    }
-  };
-
-  if (isLoading)
-    return (
-      <div className="animate-spin h-5 w-5 border-2 border-brand border-t-transparent rounded-full" />
+  const updateVariable = (index: number, key: 'name' | 'value', value: string) =>
+    onChange((current) =>
+      current.map((variable, currentIndex) =>
+        currentIndex === index ? { ...variable, [key]: value } : variable,
+      ),
     );
+
+  const deleteVariable = (index: number) =>
+    onChange((current) => current.filter((_, currentIndex) => currentIndex !== index));
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex min-h-56 flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-surface-subtle px-6 text-center">
+        <p className="text-sm font-medium">No environment variables</p>
+        <p className="mt-1 max-w-sm text-xs text-muted">
+          Add values this instance needs when it starts.
+        </p>
+        <button
+          type="button"
+          onClick={addVariable}
+          className="mt-4 inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold text-brand transition hover:bg-brand/10"
+        >
+          <Plus size={16} /> Add variable
+        </button>
+      </div>
+    );
+  }
 
   return (
     <div>
-      {envVars.length === 0 ? (
-        <div className="py-8 text-center border border-dashed border-border rounded-xl mb-4">
-          <p className="text-sm text-muted mb-3">No environment variables configured.</p>
-          <button
-            onClick={handleAdd}
-            className="px-4 py-2 border border-brand text-brand rounded-lg font-semibold hover:bg-brand/10 transition inline-flex items-center gap-2 text-sm"
-          >
-            <Plus size={16} /> Add Environment Variable
-          </button>
+      <div className="overflow-hidden rounded-xl border border-border bg-surface-raised">
+        <div className="grid grid-cols-[1fr_1fr_36px] gap-3 border-b border-border bg-surface-subtle px-4 py-2 text-[11px] font-semibold uppercase tracking-wide text-muted">
+          <span>Name</span>
+          <span>Value</span>
+          <span className="sr-only">Actions</span>
         </div>
-      ) : (
-        <>
-          <div className="border border-border rounded-xl overflow-hidden mb-4">
-            {envVars.map((env, index) => (
-              <React.Fragment key={env._rowId}>
-                {index > 0 && <hr className="border-border" />}
-                <EnvironmentVariableCard
-                  env={{ name: env.name, value: env.value || '' }}
-                  index={index}
-                  isNew={newIndices.has(index)}
-                  isModified={modifiedIndices.has(index) && !newIndices.has(index)}
-                  onChange={handleChange}
-                  onDelete={handleDelete}
-                />
-              </React.Fragment>
-            ))}
-          </div>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleAdd}
-              className="px-4 py-2 text-brand rounded-lg font-semibold hover:bg-brand/10 transition inline-flex items-center gap-2 text-sm"
-            >
-              <Plus size={16} /> Add Environment Variable
-            </button>
-            <div className="flex-1" />
-            {hasChanges && (
-              <span className="text-xs text-warning font-semibold">
-                {newIndices.size + modifiedIndices.size} unsaved change
-                {newIndices.size + modifiedIndices.size !== 1 ? 's' : ''}
-              </span>
-            )}
-            <button
-              className="px-4 py-2 bg-brand text-white rounded-lg font-semibold hover:bg-brand-end transition inline-flex items-center gap-2 text-sm disabled:opacity-50"
-              disabled={!hasChanges}
-              onClick={handleSaveAll}
-            >
-              <Save size={14} /> Save All
-            </button>
-          </div>
-        </>
-      )}
+        {rows.map((variable, index) => (
+          <EnvironmentVariableCard
+            key={variable._rowId}
+            env={variable}
+            index={index}
+            onChange={updateVariable}
+            onDelete={deleteVariable}
+          />
+        ))}
+      </div>
+      <button
+        type="button"
+        onClick={addVariable}
+        className="mt-3 inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold text-brand transition hover:bg-brand/10"
+      >
+        <Plus size={16} /> Add variable
+      </button>
     </div>
   );
 };
+
 export default EnvironmentConfigTab;

--- a/src/features/apps/components/instances/tabs/EnvironmentVariableCard.tsx
+++ b/src/features/apps/components/instances/tabs/EnvironmentVariableCard.tsx
@@ -1,59 +1,43 @@
-import React from 'react';
 import { Trash2 } from 'lucide-react';
 
 interface EnvironmentVariableCardProps {
-  env: { name: string; value: string };
+  env: { name: string; value?: string };
   index: number;
-  isNew?: boolean;
-  isModified?: boolean;
-  onChange: (index: number, key: string, value: string) => void;
+  onChange: (index: number, key: 'name' | 'value', value: string) => void;
   onDelete: (index: number) => void;
 }
 
-const EnvironmentVariableCard: React.FC<EnvironmentVariableCardProps> = ({
+const EnvironmentVariableCard = ({
   env,
   index,
-  isNew,
-  isModified,
   onChange,
   onDelete,
-}) => {
-  return (
-    <div
-      className={`flex items-center gap-3 px-4 py-3 hover:bg-surface-hover transition ${isNew ? 'border-l-[3px] border-l-success' : isModified ? 'border-l-[3px] border-l-warning' : 'border-l-[3px] border-l-transparent'}`}
+}: EnvironmentVariableCardProps) => (
+  <div className="grid grid-cols-[1fr_1fr_36px] items-center gap-3 border-b border-border px-4 py-3 last:border-b-0 focus-within:bg-surface-subtle">
+    <input
+      aria-label={`Name for environment variable ${index + 1}`}
+      placeholder="VARIABLE_NAME"
+      value={env.name}
+      onChange={(event) => onChange(index, 'name', event.target.value)}
+      className="min-w-0 rounded-lg border border-border bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder-muted outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/15"
+    />
+    <input
+      aria-label={`Value for ${env.name || `environment variable ${index + 1}`}`}
+      placeholder="value"
+      value={env.value ?? ''}
+      onChange={(event) => onChange(index, 'value', event.target.value)}
+      className="min-w-0 rounded-lg border border-border bg-surface px-3 py-2 font-mono text-sm text-text-primary placeholder-muted outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/15"
+    />
+    <button
+      type="button"
+      title="Delete environment variable"
+      aria-label="Delete environment variable"
+      className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-muted transition hover:bg-error/10 hover:text-error focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+      onClick={() => onDelete(index)}
     >
-      <input
-        placeholder="VARIABLE_NAME"
-        value={env.name}
-        onChange={(e) => onChange(index, 'name', e.target.value)}
-        className="flex-1 px-3 py-2 bg-surface rounded-lg border border-border text-text-primary placeholder-muted focus:outline-none focus:border-brand text-sm font-mono"
-      />
-      <input
-        placeholder="value"
-        value={env.value}
-        onChange={(e) => onChange(index, 'value', e.target.value)}
-        className="flex-1 px-3 py-2 bg-surface rounded-lg border border-border text-text-primary placeholder-muted focus:outline-none focus:border-brand text-sm font-mono"
-      />
-      {isNew && (
-        <span className="px-2 py-0.5 rounded-full bg-success/20 text-success text-xs font-medium">
-          New
-        </span>
-      )}
-      {isModified && !isNew && (
-        <span className="px-2 py-0.5 rounded-full bg-warning/20 text-warning text-xs font-medium">
-          Edited
-        </span>
-      )}
-      {!isNew && !isModified && <span className="w-14" />}
-      <button
-        title="Delete variable"
-        className="p-1.5 rounded-lg hover:bg-surface-hover transition text-muted hover:text-error"
-        onClick={() => onDelete(index)}
-        aria-label="Delete Environment Variable"
-      >
-        <Trash2 size={16} />
-      </button>
-    </div>
-  );
-};
+      <Trash2 size={16} />
+    </button>
+  </div>
+);
+
 export default EnvironmentVariableCard;

--- a/src/features/apps/components/instances/tabs/NetworkConfigTab.tsx
+++ b/src/features/apps/components/instances/tabs/NetworkConfigTab.tsx
@@ -35,10 +35,9 @@ export interface NetworkState {
 }
 interface NetworkConfigTabProps {
   instanceId: string;
-  onChange: (hasChanges: boolean) => void;
 }
 
-const NetworkConfigTab: React.FC<NetworkConfigTabProps> = ({ instanceId, onChange }) => {
+const NetworkConfigTab: React.FC<NetworkConfigTabProps> = ({ instanceId }) => {
   const queryClient = useQueryClient();
   const { data: networkAdaptersResponse, isLoading: loadingAdapters } =
     useGetSystemNetworkAdapters();
@@ -88,11 +87,11 @@ const NetworkConfigTab: React.FC<NetworkConfigTabProps> = ({ instanceId, onChang
       });
   }, [networkAdaptersResponse, deploymentNetworksResponse, instanceNetworksResponse]);
 
-  const invalidateAll = () => {
+  const invalidateAll = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: [`/instances/${instanceId}/config/networks`] });
     queryClient.invalidateQueries({ queryKey: [`/deployments/default/networks`] });
     queryClient.invalidateQueries({ queryKey: [`/system/network/adapters`] });
-  };
+  }, [instanceId, queryClient]);
 
   const handleNetworkActivationChange = useCallback(
     async (event: React.ChangeEvent<HTMLInputElement>, id: string, name: string) => {
@@ -128,7 +127,15 @@ const NetworkConfigTab: React.FC<NetworkConfigTabProps> = ({ instanceId, onChang
         toast.error('Failed to save Network config!');
       }
     },
-    [networks, instanceId],
+    [
+      connectNetwork,
+      createDeploymentNetwork,
+      disconnectNetwork,
+      instanceId,
+      invalidateAll,
+      networks,
+      reserveIp,
+    ],
   );
 
   if (loading)

--- a/src/features/apps/components/instances/tabs/PortRangeMapping.tsx
+++ b/src/features/apps/components/instances/tabs/PortRangeMapping.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import { Trash2, Save, ChevronsRight, Server, Container } from 'lucide-react';
-import TransportProtocolSelector from './TransportProtocolSelector';
-import {
+import { Container, Server, Trash2 } from 'lucide-react';
+import type {
   InstancePortMappingRange,
   InstancePortMappingSingle,
   TransportProtocol,
 } from '@generated/core/schemas';
+import TransportProtocolSelector from './TransportProtocolSelector';
 
 interface PortRangeMappingProps {
   port: InstancePortMappingRange;
@@ -16,104 +15,97 @@ interface PortRangeMappingProps {
     field: keyof InstancePortMappingSingle | keyof InstancePortMappingRange,
     value: number | { start?: number; end?: number },
   ) => void;
-  sx?: object;
-  handleDeletePort: (index: number) => void;
-  handleSavePort: (protocol: string, index: number) => void;
-  handleProtocolChange: (index: number, protocol: TransportProtocol) => void;
+  onDelete: (index: number) => void;
+  onProtocolChange: (index: number, protocol: TransportProtocol) => void;
 }
 
-const PortRangeMapping: React.FC<PortRangeMappingProps> = ({
+const numericValue = (value: string) => (value === '' ? 0 : Number(value));
+
+const RangeInputs = ({
+  label,
+  icon,
+  start,
+  end,
+  onStart,
+  onEnd,
+}: {
+  label: string;
+  icon: React.ReactNode;
+  start: number;
+  end: number;
+  onStart: (value: number) => void;
+  onEnd: (value: number) => void;
+}) => (
+  <fieldset className="min-w-0">
+    <legend className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted">
+      {icon} {label}
+    </legend>
+    <div className="grid grid-cols-[1fr_12px_1fr] items-center gap-1">
+      <input
+        type="number"
+        min={1}
+        max={65535}
+        aria-label={`${label} start`}
+        value={start || ''}
+        onChange={(event) => onStart(numericValue(event.target.value))}
+        className="min-w-0 rounded-lg border border-border bg-surface px-2 py-2 text-sm text-text-primary outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/15"
+      />
+      <span className="text-center text-muted">-</span>
+      <input
+        type="number"
+        min={1}
+        max={65535}
+        aria-label={`${label} end`}
+        value={end || ''}
+        onChange={(event) => onEnd(numericValue(event.target.value))}
+        className="min-w-0 rounded-lg border border-border bg-surface px-2 py-2 text-sm text-text-primary outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/15"
+      />
+    </div>
+  </fieldset>
+);
+
+const PortRangeMapping = ({
   port,
   protocol,
   index,
   onChange,
-  handleDeletePort,
-  handleSavePort,
-  handleProtocolChange,
-}) => {
-  const [changes, setChanges] = React.useState(false);
-  return (
-    <div className="flex items-center w-full p-4 mb-2 rounded-xl bg-surface-raised border border-border gap-2">
-      <span className="inline-flex items-center justify-center w-6 h-6">
-        <ChevronsRight size={18} />
-      </span>
-      <div className="flex items-center gap-1 w-46">
-        <span title="Host" className="inline-flex items-center text-muted">
-          <Server size={16} />
-        </span>
-        <input
-          className="w-18 px-3 py-2 bg-surface rounded-lg border border-border text-text-primary text-sm focus:outline-none focus:border-brand"
-          placeholder="Start"
-          aria-label="Host range start"
-          value={port.host_ports.start}
-          onChange={(e) => {
-            setChanges(true);
-            onChange(index, 'host_ports', { start: parseInt(e.target.value, 10) || 0 });
-          }}
-        />
-        <span className="text-muted">-</span>
-        <input
-          className="w-18 px-3 py-2 bg-surface rounded-lg border border-border text-text-primary text-sm focus:outline-none focus:border-brand"
-          placeholder="End"
-          aria-label="Host range end"
-          value={port.host_ports.end}
-          onChange={(e) => {
-            setChanges(true);
-            onChange(index, 'host_ports', { end: parseInt(e.target.value, 10) || 0 });
-          }}
-        />
-      </div>
-      <div className="flex items-center gap-1 w-46">
-        <span title="Container" className="inline-flex items-center text-muted">
-          <Container size={16} />
-        </span>
-        <input
-          className="w-18 px-3 py-2 bg-surface rounded-lg border border-border text-text-primary text-sm focus:outline-none focus:border-brand"
-          placeholder="Start"
-          aria-label="Container range start"
-          value={port.container_ports.start}
-          onChange={(e) =>
-            onChange(index, 'container_ports', { start: parseInt(e.target.value, 10) || 0 })
-          }
-        />
-        <span className="text-muted">-</span>
-        <input
-          className="w-18 px-3 py-2 bg-surface rounded-lg border border-border text-text-primary text-sm focus:outline-none focus:border-brand"
-          placeholder="End"
-          aria-label="Container range end"
-          value={port.container_ports.end}
-          onChange={(e) =>
-            onChange(index, 'container_ports', { end: parseInt(e.target.value, 10) || 0 })
-          }
-        />
-      </div>
+  onDelete,
+  onProtocolChange,
+}: PortRangeMappingProps) => (
+  <div className="grid grid-cols-[1fr_1fr_92px_36px] items-end gap-3 rounded-xl border border-border bg-surface-raised p-3">
+    <RangeInputs
+      label="Host range"
+      icon={<Server size={14} />}
+      start={port.host_ports.start}
+      end={port.host_ports.end}
+      onStart={(value) => onChange(index, 'host_ports', { start: value })}
+      onEnd={(value) => onChange(index, 'host_ports', { end: value })}
+    />
+    <RangeInputs
+      label="Container range"
+      icon={<Container size={14} />}
+      start={port.container_ports.start}
+      end={port.container_ports.end}
+      onStart={(value) => onChange(index, 'container_ports', { start: value })}
+      onEnd={(value) => onChange(index, 'container_ports', { end: value })}
+    />
+    <div>
+      <span className="mb-1.5 block text-xs font-medium text-muted">Protocol</span>
       <TransportProtocolSelector
         value={protocol}
-        onChange={(p) => {
-          handleProtocolChange(index, p);
-          setChanges(true);
-        }}
+        onChange={(value) => onProtocolChange(index, value)}
       />
-      <button
-        title="Delete Port Mapping"
-        className="p-1.5 rounded-lg hover:bg-surface-hover transition ml-auto"
-        onClick={() => handleDeletePort(index)}
-      >
-        <Trash2 size={18} />
-      </button>
-      <button
-        title="Save Port Mapping"
-        aria-label="Save Port Mapping"
-        className="p-1.5 rounded-lg hover:bg-surface-hover transition disabled:opacity-30"
-        disabled={!changes}
-        onClick={() => {
-          handleSavePort(protocol, index);
-          setChanges(false);
-        }}
-      >
-        <Save size={18} />
-      </button>
     </div>
-  );
-};
+    <button
+      type="button"
+      title="Delete port mapping"
+      aria-label="Delete port mapping"
+      onClick={() => onDelete(index)}
+      className="mb-0.5 inline-flex h-9 w-9 items-center justify-center rounded-lg text-muted transition hover:bg-error/10 hover:text-error focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+    >
+      <Trash2 size={16} />
+    </button>
+  </div>
+);
+
 export default PortRangeMapping;

--- a/src/features/apps/components/instances/tabs/PortsConfigTab.test.tsx
+++ b/src/features/apps/components/instances/tabs/PortsConfigTab.test.tsx
@@ -1,72 +1,39 @@
-/**
- * Regression test for commit da0a679 — port mapping row identity survives
- * deletion. Same pattern as EnvironmentConfigTab.test.tsx.
- *
- * Pre-fix, PortsConfigTab keyed its rows by array index. Deleting row 0 caused
- * React to reuse the mounted input DOM for row 1 — user saw row 0's typed
- * ports appear in row 1. The stable `_rowId` (crypto.randomUUID) fixes this.
- */
-import React from 'react';
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import PortsConfigTab from './PortsConfigTab';
+import type { PortDraft } from '../useInstanceConfigDraft';
 
-// Stable reference — see EnvironmentConfigTab.test for the OOM gotcha.
-vi.mock('@generated/core/instances/instances', () => {
-  const stablePortsResponse = { data: { tcp: [], udp: [] }, status: 200 };
-  return {
-    useGetInstancesInstanceIdConfigPorts: () => ({
-      data: stablePortsResponse,
-      isLoading: false,
-    }),
-    usePutInstancesInstanceIdConfigPortsTransportProtocol: () => ({ mutateAsync: vi.fn() }),
-    getGetInstancesInstanceIdConfigPortsQueryKey: (instanceId: string) => [
-      `/instances/${instanceId}/config/ports`,
-    ],
-  };
-});
+const Harness = () => {
+  const [rows, setRows] = useState<PortDraft[]>([]);
+  return <PortsConfigTab rows={rows} onChange={(update) => setRows(update)} />;
+};
 
-function renderWithClient(ui: React.ReactElement) {
-  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
-}
+describe('PortsConfigTab row identity', () => {
+  it('preserves the second mapping values when the first mapping is deleted', async () => {
+    render(<Harness />);
 
-describe('PortsConfigTab — row identity', () => {
-  it('deleting row 0 preserves row 1 port values (no identity bleed)', async () => {
-    renderWithClient(<PortsConfigTab instanceId="42" onChange={vi.fn()} />);
-
-    // Add first row via the "one-to-one" button (identified by title attr).
     const addButton = screen.getByTitle(/add a one-to-one port mapping/i);
     fireEvent.click(addButton);
 
-    // Fill row 0: host 8080 → container 80.
-    let hostInputs = screen.getAllByLabelText(/host port/i);
-    let containerInputs = screen.getAllByLabelText(/container port/i);
-    expect(hostInputs).toHaveLength(1);
+    let hostInputs = screen.getAllByLabelText('Host port');
+    let containerInputs = screen.getAllByLabelText('Container port');
     fireEvent.change(hostInputs[0], { target: { value: '8080' } });
     fireEvent.change(containerInputs[0], { target: { value: '80' } });
 
-    // Add second row.
     fireEvent.click(addButton);
-    hostInputs = screen.getAllByLabelText(/host port/i);
-    containerInputs = screen.getAllByLabelText(/container port/i);
-    expect(hostInputs).toHaveLength(2);
+    hostInputs = screen.getAllByLabelText('Host port');
+    containerInputs = screen.getAllByLabelText('Container port');
     fireEvent.change(hostInputs[1], { target: { value: '9090' } });
     fireEvent.change(containerInputs[1], { target: { value: '90' } });
 
-    // Delete row 0.
-    const deleteButtons = screen.getAllByTitle(/delete port mapping/i);
-    fireEvent.click(deleteButtons[0]);
+    fireEvent.click(screen.getAllByRole('button', { name: /delete port mapping/i })[0]);
 
-    // Regression assertion: one row remains with row 1's values (9090/90),
-    // not row 0's (8080/80).
     await waitFor(() => {
-      const remaining = screen.getAllByLabelText(/host port/i);
+      const remaining = screen.getAllByLabelText('Host port');
       expect(remaining).toHaveLength(1);
-      expect((remaining[0] as HTMLInputElement).value).toBe('9090');
+      expect(remaining[0]).toHaveValue(9090);
     });
-    const containerAfter = screen.getAllByLabelText(/container port/i);
-    expect((containerAfter[0] as HTMLInputElement).value).toBe('90');
+    expect(screen.getByLabelText('Container port')).toHaveValue(90);
   });
 });

--- a/src/features/apps/components/instances/tabs/PortsConfigTab.tsx
+++ b/src/features/apps/components/instances/tabs/PortsConfigTab.tsx
@@ -1,206 +1,146 @@
-import React, { useEffect, useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
-import { toast } from 'sonner';
-import SinglePortMapping from './SinglePortMapping';
-import PortRangeMapping from './PortRangeMapping';
-import AddSinglePortMappingButton from './AddSinglePortMappingButton';
-import AddPortRangeMappingButton from './AddPortRangeMappingButton';
+import { Plus } from 'lucide-react';
 import {
-  InstancePortMapping,
-  InstancePortMappingRange,
-  InstancePortMappingSingle,
-  InstancePorts,
   TransportProtocol,
+  type InstancePortMappingRange,
+  type InstancePortMappingSingle,
 } from '@generated/core/schemas';
-import {
-  useGetInstancesInstanceIdConfigPorts,
-  usePutInstancesInstanceIdConfigPortsTransportProtocol,
-  getGetInstancesInstanceIdConfigPortsQueryKey,
-} from '@generated/core/instances/instances';
 import HelpButton from '@app/layout/HelpButton';
 import { instancedeviceconfig } from '@app/layout/helplinks';
-import { getErrorMessage } from '@app/api/fetch-error';
+import type { PortDraft } from '../useInstanceConfigDraft';
+import PortRangeMapping from './PortRangeMapping';
+import SinglePortMapping from './SinglePortMapping';
 
 interface PortsConfigTabProps {
-  instanceId: string;
-  onChange: (hasChanges: boolean) => void;
-}
-// Client-side row identity — stable across edits so React reconciliation keeps input focus
-// on the correct row even after additions/deletions. Not sent to the server.
-interface PortWithProtocol {
-  protocol: TransportProtocol;
-  port: InstancePortMappingSingle | InstancePortMappingRange;
-  _rowId: string;
+  rows: PortDraft[];
+  onChange: (update: (rows: PortDraft[]) => PortDraft[]) => void;
 }
 
-const PortsConfigTab: React.FC<PortsConfigTabProps> = ({ instanceId, onChange }) => {
-  const [ports, setPorts] = useState<PortWithProtocol[]>([]);
-  const [initialized, setInitialized] = useState(false);
-  const [save, setSave] = useState(false);
-  const queryClient = useQueryClient();
-  const { data: portsResponse, isLoading } = useGetInstancesInstanceIdConfigPorts(instanceId);
-  const { mutateAsync: putPorts } = usePutInstancesInstanceIdConfigPortsTransportProtocol();
+type PortField = keyof InstancePortMappingSingle | keyof InstancePortMappingRange;
 
-  useEffect(() => {
-    if (portsResponse?.data && !initialized) {
-      const portData = portsResponse.data as InstancePorts;
-      setPorts([
-        ...portData.tcp.map(
-          (port: InstancePortMapping): PortWithProtocol => ({
-            protocol: TransportProtocol.tcp,
-            port,
-            _rowId: crypto.randomUUID(),
-          }),
-        ),
-        ...portData.udp.map(
-          (port: InstancePortMapping): PortWithProtocol => ({
-            protocol: TransportProtocol.udp,
-            port,
-            _rowId: crypto.randomUUID(),
-          }),
-        ),
-      ]);
-      setInitialized(true);
-    }
-  }, [portsResponse, initialized]);
-  useEffect(() => {
-    if (save) {
-      handleSave();
-      setSave(false);
-    }
-  }, [save]);
+const PortsConfigTab = ({ rows, onChange }: PortsConfigTabProps) => {
+  const addSingle = () =>
+    onChange((current) => [
+      ...current,
+      {
+        protocol: TransportProtocol.tcp,
+        port: { host_port: 0, container_port: 0 },
+        _rowId: crypto.randomUUID(),
+      },
+    ]);
 
-  const handlePortChange = (
+  const addRange = () =>
+    onChange((current) => [
+      ...current,
+      {
+        protocol: TransportProtocol.tcp,
+        port: {
+          host_ports: { start: 0, end: 0 },
+          container_ports: { start: 0, end: 0 },
+        },
+        _rowId: crypto.randomUUID(),
+      },
+    ]);
+
+  const updatePort = (
     index: number,
-    field: keyof InstancePortMappingSingle | keyof InstancePortMappingRange,
+    field: PortField,
     value: number | { start?: number; end?: number },
-  ) => {
-    setPorts((prev) => {
-      const u = [...prev];
-      const p = u[index];
-      if ('host_port' in p.port) {
-        p.port = { ...p.port, [field]: value } as InstancePortMappingSingle;
-      } else if ('host_ports' in p.port) {
-        p.port = {
-          ...p.port,
-          [field]: {
-            ...(field in p.port ? (p.port[field as keyof InstancePortMappingRange] as object) : {}),
-            ...(value as object),
+  ) =>
+    onChange((current) =>
+      current.map((row, currentIndex) => {
+        if (currentIndex !== index) return row;
+        if ('host_port' in row.port) {
+          return {
+            ...row,
+            port: { ...row.port, [field]: value } as InstancePortMappingSingle,
+          };
+        }
+        const rangeField = field as 'host_ports' | 'container_ports';
+        return {
+          ...row,
+          port: {
+            ...row.port,
+            [rangeField]: { ...row.port[rangeField], ...(value as object) },
           },
-        } as InstancePortMappingRange;
-      }
-      return u;
-    });
-  };
-  const handleProtocolChange = (index: number, protocol: TransportProtocol) => {
-    setPorts((prev) => {
-      const u = [...prev];
-      u[index].protocol = protocol;
-      return u;
-    });
-  };
-  const handleSave = async () => {
-    try {
-      const tcp = ports.filter((p) => p.protocol === TransportProtocol.tcp).map((p) => p.port);
-      const udp = ports.filter((p) => p.protocol === TransportProtocol.udp).map((p) => p.port);
-      // Always PUT both protocols. The endpoint replaces the full set for a
-      // protocol, and an empty array clears it. A `length > 0` guard would skip
-      // the request when the last port of a protocol is deleted, so the deletion
-      // never reached the server and the removed port reappeared on reload.
-      await putPorts({ instanceId, transportProtocol: TransportProtocol.tcp, data: tcp });
-      await putPorts({ instanceId, transportProtocol: TransportProtocol.udp, data: udp });
-      // The PUT mutation doesn't touch the ports GET cache, so without this the
-      // 30s global staleTime keeps serving the pre-save snapshot when the tab is
-      // reopened. Invalidate so a reopen re-reads fresh server state.
-      await queryClient.invalidateQueries({
-        queryKey: getGetInstancesInstanceIdConfigPortsQueryKey(instanceId),
-      });
-      onChange(true);
-      toast.success('Port mappings saved!');
-    } catch (error) {
-      toast.error(getErrorMessage(error));
-    }
-  };
-  const handleDeletePort = (index: number) => {
-    setPorts((prev) => {
-      const u = [...prev];
-      u.splice(index, 1);
-      return u;
-    });
-    setSave(true);
-  };
-
-  if (isLoading)
-    return (
-      <div className="animate-spin h-5 w-5 border-2 border-brand border-t-transparent rounded-full" />
+        };
+      }),
     );
+
+  const updateProtocol = (index: number, protocol: TransportProtocol) =>
+    onChange((current) =>
+      current.map((row, currentIndex) => (currentIndex === index ? { ...row, protocol } : row)),
+    );
+
+  const deletePort = (index: number) =>
+    onChange((current) => current.filter((_, currentIndex) => currentIndex !== index));
 
   return (
     <div>
-      <div className="flex items-center gap-2 mb-4">
-        <h6 className="text-base font-semibold">Port Mappings</h6>
-        <HelpButton url={instancedeviceconfig} />
+      <div className="mb-4 flex items-center justify-between gap-3">
+        <div className="flex items-center gap-1">
+          <p className="text-sm font-medium">Mappings</p>
+          <HelpButton url={instancedeviceconfig} />
+        </div>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            title="Add a one-to-one port mapping"
+            onClick={addSingle}
+            className="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-semibold text-brand transition hover:bg-brand/10"
+          >
+            <Plus size={15} /> Add port
+          </button>
+          <button
+            type="button"
+            title="Add a range of ports"
+            onClick={addRange}
+            className="inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-sm font-semibold text-brand transition hover:bg-brand/10"
+          >
+            <Plus size={15} /> Add range
+          </button>
+        </div>
       </div>
-      <div className="flex flex-wrap gap-2 mb-4">
-        <AddSinglePortMappingButton
-          onAdd={() =>
-            setPorts((prev) => [
-              ...prev,
-              {
-                protocol: TransportProtocol.tcp,
-                port: { host_port: 0, container_port: 0 } as InstancePortMappingSingle,
-                _rowId: crypto.randomUUID(),
-              },
-            ])
-          }
-          defaultProtocol={TransportProtocol.tcp}
-        />
-        <AddPortRangeMappingButton
-          onAdd={() =>
-            setPorts((prev) => [
-              ...prev,
-              {
-                protocol: TransportProtocol.tcp,
-                port: {
-                  host_ports: { start: 0, end: 0 },
-                  container_ports: { start: 0, end: 0 },
-                } as InstancePortMappingRange,
-                _rowId: crypto.randomUUID(),
-              },
-            ])
-          }
-          defaultProtocol={TransportProtocol.tcp}
-        />
-      </div>
-      <div>
-        {ports.length === 0 && <p className="text-sm text-muted">No ports configured.</p>}
-        {ports.map((p, index) =>
-          'host_port' in p.port ? (
-            <SinglePortMapping
-              key={p._rowId}
-              port={p.port as InstancePortMappingSingle}
-              protocol={p.protocol}
-              index={index}
-              onChange={handlePortChange}
-              handleDeletePort={handleDeletePort}
-              handleSavePort={handleSave}
-              handleProtocolChange={handleProtocolChange}
-            />
-          ) : (
-            <PortRangeMapping
-              key={p._rowId}
-              port={p.port as InstancePortMappingRange}
-              protocol={p.protocol}
-              index={index}
-              onChange={handlePortChange}
-              handleDeletePort={handleDeletePort}
-              handleSavePort={handleSave}
-              handleProtocolChange={handleProtocolChange}
-            />
-          ),
-        )}
-      </div>
+      {rows.length === 0 ? (
+        <div className="flex min-h-48 flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-surface-subtle px-6 text-center">
+          <p className="text-sm font-medium">No port mappings</p>
+          <p className="mt-1 text-xs text-muted">Add a port to make this instance reachable.</p>
+          <button
+            type="button"
+            onClick={addSingle}
+            className="mt-4 inline-flex items-center gap-2 rounded-lg px-3 py-2 text-sm font-semibold text-brand transition hover:bg-brand/10"
+          >
+            <Plus size={16} /> Add port
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row, index) =>
+            'host_port' in row.port ? (
+              <SinglePortMapping
+                key={row._rowId}
+                port={row.port}
+                protocol={row.protocol}
+                index={index}
+                onChange={updatePort}
+                onDelete={deletePort}
+                onProtocolChange={updateProtocol}
+              />
+            ) : (
+              <PortRangeMapping
+                key={row._rowId}
+                port={row.port}
+                protocol={row.protocol}
+                index={index}
+                onChange={updatePort}
+                onDelete={deletePort}
+                onProtocolChange={updateProtocol}
+              />
+            ),
+          )}
+        </div>
+      )}
     </div>
   );
 };
+
 export default PortsConfigTab;

--- a/src/features/apps/components/instances/tabs/SinglePortMapping.tsx
+++ b/src/features/apps/components/instances/tabs/SinglePortMapping.tsx
@@ -1,11 +1,10 @@
-import React from 'react';
-import { Trash2, ArrowRight, Save, Server, Container } from 'lucide-react';
-import TransportProtocolSelector from './TransportProtocolSelector';
-import {
+import { ArrowRight, Container, Server, Trash2 } from 'lucide-react';
+import type {
   InstancePortMappingRange,
   InstancePortMappingSingle,
   TransportProtocol,
 } from '@generated/core/schemas';
+import TransportProtocolSelector from './TransportProtocolSelector';
 
 interface SinglePortMappingProps {
   port: InstancePortMappingSingle;
@@ -16,84 +15,67 @@ interface SinglePortMappingProps {
     field: keyof InstancePortMappingSingle | keyof InstancePortMappingRange,
     value: number | { start?: number; end?: number },
   ) => void;
-  sx?: object;
-  handleDeletePort: (index: number) => void;
-  handleSavePort: (protocol: string, index: number) => void;
-  handleProtocolChange: (index: number, protocol: TransportProtocol) => void;
+  onDelete: (index: number) => void;
+  onProtocolChange: (index: number, protocol: TransportProtocol) => void;
 }
 
-const SinglePortMapping: React.FC<SinglePortMappingProps> = ({
+const numericValue = (value: string) => (value === '' ? 0 : Number(value));
+
+const SinglePortMapping = ({
   port,
   protocol,
   index,
   onChange,
-  handleDeletePort,
-  handleSavePort,
-  handleProtocolChange,
-}) => {
-  const [changes, setChanges] = React.useState(false);
-  return (
-    <div className="flex items-center w-full p-4 mb-2 rounded-xl bg-surface-raised border border-border gap-2">
-      <span className="inline-flex items-center justify-center w-6 h-6">
-        <ArrowRight size={18} />
+  onDelete,
+  onProtocolChange,
+}: SinglePortMappingProps) => (
+  <div className="grid grid-cols-[1fr_24px_1fr_92px_36px] items-end gap-2 rounded-xl border border-border bg-surface-raised p-3">
+    <label className="min-w-0">
+      <span className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted">
+        <Server size={14} /> Host port
       </span>
-      <div className="flex items-center gap-1 w-46">
-        <span title="Host" className="inline-flex items-center text-muted">
-          <Server size={16} />
-        </span>
-        <input
-          className="flex-1 min-w-0 px-3 py-2 bg-surface rounded-lg border border-border text-text-primary text-sm focus:outline-none focus:border-brand"
-          placeholder="Port"
-          aria-label="Host port"
-          value={port.host_port}
-          onChange={(e) => {
-            setChanges(true);
-            onChange(index, 'host_port', parseInt(e.target.value, 10) || 0);
-          }}
-        />
-      </div>
-      <div className="flex items-center gap-1 w-46">
-        <span title="Container" className="inline-flex items-center text-muted">
-          <Container size={16} />
-        </span>
-        <input
-          className="flex-1 min-w-0 px-3 py-2 bg-surface rounded-lg border border-border text-text-primary text-sm focus:outline-none focus:border-brand"
-          placeholder="Port"
-          aria-label="Container port"
-          value={port.container_port}
-          onChange={(e) => {
-            setChanges(true);
-            onChange(index, 'container_port', parseInt(e.target.value, 10) || 0);
-          }}
-        />
-      </div>
+      <input
+        type="number"
+        min={1}
+        max={65535}
+        aria-label="Host port"
+        value={port.host_port || ''}
+        onChange={(event) => onChange(index, 'host_port', numericValue(event.target.value))}
+        className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text-primary outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/15"
+      />
+    </label>
+    <ArrowRight size={16} className="mb-2.5 text-muted" aria-hidden="true" />
+    <label className="min-w-0">
+      <span className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-muted">
+        <Container size={14} /> Container port
+      </span>
+      <input
+        type="number"
+        min={1}
+        max={65535}
+        aria-label="Container port"
+        value={port.container_port || ''}
+        onChange={(event) => onChange(index, 'container_port', numericValue(event.target.value))}
+        className="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-text-primary outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/15"
+      />
+    </label>
+    <div>
+      <span className="mb-1.5 block text-xs font-medium text-muted">Protocol</span>
       <TransportProtocolSelector
         value={protocol}
-        onChange={(p) => {
-          handleProtocolChange(index, p);
-          setChanges(true);
-        }}
+        onChange={(value) => onProtocolChange(index, value)}
       />
-      <button
-        title="Delete Port Mapping"
-        className="p-1.5 rounded-lg hover:bg-surface-hover transition ml-auto"
-        onClick={() => handleDeletePort(index)}
-      >
-        <Trash2 size={18} />
-      </button>
-      <button
-        title="Save Port Mapping"
-        aria-label="Save Port Mapping"
-        className="p-1.5 rounded-lg hover:bg-surface-hover transition disabled:opacity-30"
-        disabled={!changes}
-        onClick={() => {
-          handleSavePort(protocol as TransportProtocol, index);
-          setChanges(false);
-        }}
-      >
-        <Save size={18} />
-      </button>
     </div>
-  );
-};
+    <button
+      type="button"
+      title="Delete port mapping"
+      aria-label="Delete port mapping"
+      onClick={() => onDelete(index)}
+      className="mb-0.5 inline-flex h-9 w-9 items-center justify-center rounded-lg text-muted transition hover:bg-error/10 hover:text-error focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand"
+    >
+      <Trash2 size={16} />
+    </button>
+  </div>
+);
+
 export default SinglePortMapping;

--- a/src/features/apps/components/instances/tabs/TransportProtocolSelector.tsx
+++ b/src/features/apps/components/instances/tabs/TransportProtocolSelector.tsx
@@ -14,13 +14,14 @@ const TransportProtocolSelector: React.FC<TransportProtocolSelectorProps> = ({
 }) => {
   return (
     <select
-      aria-label="Transport Protocol"
+      aria-label="Transport protocol"
       value={value}
       onChange={(e) => onChange(e.target.value as TransportProtocol)}
-      className="px-3 py-2 bg-surface rounded-lg border border-border text-text-primary text-sm focus:outline-none focus:border-brand"
+      className="w-full rounded-lg border border-border bg-surface px-2 py-2 text-sm text-text-primary outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/15"
     >
       <option value={TransportProtocol.tcp}>TCP</option>
       <option value={TransportProtocol.udp}>UDP</option>
+      <option value={TransportProtocol.sctp}>SCTP</option>
     </select>
   );
 };

--- a/src/features/apps/components/instances/tabs/UsbConfigCard.tsx
+++ b/src/features/apps/components/instances/tabs/UsbConfigCard.tsx
@@ -1,44 +1,46 @@
-import React from 'react';
-import { X, CheckCircle2, Usb } from 'lucide-react';
-import { UsbDevice } from './UsbConfigTab';
+import { Usb } from 'lucide-react';
+import type { UsbDraft } from '../useInstanceConfigDraft';
 
 interface UsbConfigCardProps {
-  device: UsbDevice;
-  onEnable: (port: string, enabled: boolean) => void;
+  device: UsbDraft;
+  onToggle: (port: string) => void;
 }
 
-const UsbConfigCard: React.FC<UsbConfigCardProps> = ({ device, onEnable }) => {
-  return (
-    <div className="flex items-center w-full p-4 mb-2 rounded-xl bg-surface-raised border border-border">
-      <span
-        title={`USB device ${device.name} ${device.enabled ? 'enabled in app' : 'disabled in app'}`}
-      >
-        <Usb
-          style={{ marginRight: 16 }}
-          color={device.enabled ? 'var(--color-success)' : 'var(--color-error)'}
-          size={24}
-        />
-      </span>
-      <div className="flex-1 mr-2">
-        <p className="text-sm font-medium">{device.port}</p>
-        <p className="text-xs text-muted">Port</p>
+const UsbConfigCard = ({ device, onToggle }: UsbConfigCardProps) => (
+  <div className="flex items-center gap-3 rounded-xl border border-border bg-surface-raised px-4 py-3">
+    <span className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-surface-subtle text-muted">
+      <Usb size={18} aria-hidden="true" />
+    </span>
+    <div className="min-w-0 flex-1">
+      <div className="flex items-center gap-2">
+        <p className="truncate text-sm font-medium">{device.name}</p>
+        {!device.device_connected && (
+          <span className="rounded-full bg-warning/10 px-2 py-0.5 text-[11px] font-medium text-warning">
+            Disconnected
+          </span>
+        )}
       </div>
-      <div className="flex-1 mr-2">
-        <p className="text-sm font-medium">{device.name}</p>
-        <p className="text-xs text-muted">Name</p>
-      </div>
-      <div className="flex-1 mr-2">
-        <p className="text-sm font-medium">{device.vendor}</p>
-        <p className="text-xs text-muted">Vendor</p>
-      </div>
-      <button
-        className={`px-4 py-2 rounded-lg font-semibold transition inline-flex items-center gap-2 shrink-0 ${device.enabled ? 'text-error hover:bg-error/10' : 'text-success hover:bg-success/10'}`}
-        onClick={() => onEnable(device.port, device.enabled)}
-      >
-        {device.enabled ? <X size={18} /> : <CheckCircle2 size={18} />}{' '}
-        {device.enabled ? 'Disable' : 'Enable'}
-      </button>
+      <p className="truncate text-xs text-muted">
+        {device.vendor} · Port {device.port}
+      </p>
     </div>
-  );
-};
+    <button
+      type="button"
+      role="switch"
+      aria-checked={device.enabled}
+      aria-label={`${device.name} access`}
+      onClick={() => onToggle(device.port)}
+      className={`relative h-6 w-11 shrink-0 rounded-full transition-all hover:brightness-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand focus-visible:ring-offset-2 focus-visible:ring-offset-surface-raised ${
+        device.enabled ? 'bg-brand' : 'bg-border-strong'
+      }`}
+    >
+      <span
+        className={`absolute left-0.5 top-0.5 h-5 w-5 rounded-full bg-white shadow-sm ring-1 ring-black/5 transition-transform ${
+          device.enabled ? 'translate-x-5' : 'translate-x-0'
+        }`}
+      />
+    </button>
+  </div>
+);
+
 export default UsbConfigCard;

--- a/src/features/apps/components/instances/tabs/UsbConfigTab.tsx
+++ b/src/features/apps/components/instances/tabs/UsbConfigTab.tsx
@@ -1,96 +1,34 @@
-import React, { useMemo } from 'react';
-import { toast } from 'sonner';
-import { UsbDevice as SystemUsbDevice, InstanceConfigUsbDevice } from '@generated/core/schemas';
-import {
-  useGetInstancesInstanceIdConfigDevicesUsb,
-  usePutInstancesInstanceIdConfigDevicesUsbPort,
-  useDeleteInstancesInstanceIdConfigDevicesUsbPort,
-} from '@generated/core/instances/instances';
-import { useGetSystemDevicesUsb } from '@generated/core/system/system';
-import { useQueryClient } from '@tanstack/react-query';
 import HelpButton from '@app/layout/HelpButton';
 import { instancedeviceconfig } from '@app/layout/helplinks';
+import type { UsbDraft } from '../useInstanceConfigDraft';
 import UsbConfigCard from './UsbConfigCard';
 
-export interface UsbDevice {
-  port: string;
-  name: string;
-  vendor: string;
-  device_connected: boolean;
-  enabled: boolean;
-}
 interface UsbConfigTabProps {
-  instanceId: string;
-  onChange: (hasChanges: boolean) => void;
+  devices: UsbDraft[];
+  onToggle: (port: string) => void;
 }
 
-const UsbConfigTab: React.FC<UsbConfigTabProps> = ({ instanceId, onChange }) => {
-  const queryClient = useQueryClient();
-  const { data: systemDevicesResponse, isLoading: loadingSystem } = useGetSystemDevicesUsb();
-  const { data: instanceDevicesResponse, isLoading: loadingInstance } =
-    useGetInstancesInstanceIdConfigDevicesUsb(instanceId);
-  const { mutateAsync: enableUsb } = usePutInstancesInstanceIdConfigDevicesUsbPort();
-  const { mutateAsync: disableUsb } = useDeleteInstancesInstanceIdConfigDevicesUsbPort();
-  const loading = loadingSystem || loadingInstance;
-
-  const usbDevices: UsbDevice[] = useMemo(() => {
-    const systemData = systemDevicesResponse?.data as SystemUsbDevice[] | undefined;
-    const instanceData = instanceDevicesResponse?.data as InstanceConfigUsbDevice[] | undefined;
-    if (!systemData || !instanceData) return [];
-    const devices: UsbDevice[] = systemData.map((d) => {
-      const inst = instanceData.find((i) => i.port === d.port);
-      return {
-        port: d.port,
-        name: d.name ?? 'Unknown',
-        vendor: d.vendor ?? 'Unknown',
-        device_connected: inst?.device_connected ?? true,
-        enabled: !!inst,
-      };
-    });
-    instanceData.forEach((inst) => {
-      if (!systemData.some((s) => s.port === inst.port))
-        devices.push({
-          port: inst.port,
-          name: inst.name ?? 'Unknown',
-          vendor: inst.vendor ?? 'Unknown',
-          device_connected: false,
-          enabled: true,
-        });
-    });
-    devices.sort((a, b) => a.port.localeCompare(b.port));
-    return devices;
-  }, [systemDevicesResponse, instanceDevicesResponse]);
-
-  const handleToggle = async (port: string, enabled: boolean) => {
-    try {
-      if (!enabled) await enableUsb({ instanceId, port });
-      else await disableUsb({ instanceId, port });
-      onChange(true);
-      queryClient.invalidateQueries({ queryKey: [`/instances/${instanceId}/config/devices/usb`] });
-      queryClient.invalidateQueries({ queryKey: [`/system/devices/usb`] });
-      toast.success('USB config saved!');
-    } catch {
-      toast.error('Failed to save USB config!');
-    }
-  };
-
-  if (loading)
-    return (
-      <div className="animate-spin h-5 w-5 border-2 border-brand border-t-transparent rounded-full" />
-    );
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-4">
-        <h6 className="text-base font-semibold">USB Devices</h6>
-        <HelpButton url={instancedeviceconfig} />
+const UsbConfigTab = ({ devices, onToggle }: UsbConfigTabProps) => (
+  <div>
+    <div className="mb-4 flex items-center gap-1">
+      <p className="text-sm font-medium">Available devices</p>
+      <HelpButton url={instancedeviceconfig} />
+    </div>
+    {devices.length === 0 ? (
+      <div className="flex min-h-48 flex-col items-center justify-center rounded-2xl border border-dashed border-border bg-surface-subtle px-6 text-center">
+        <p className="text-sm font-medium">No USB devices found</p>
+        <p className="mt-1 text-xs text-muted">
+          Connect a USB device to the host and it will appear here.
+        </p>
       </div>
-      <div>
-        {usbDevices.length === 0 && <p className="text-sm">No USB devices available.</p>}
-        {usbDevices.map((d) => (
-          <UsbConfigCard key={d.port} device={d} onEnable={handleToggle} />
+    ) : (
+      <div className="space-y-2">
+        {devices.map((device) => (
+          <UsbConfigCard key={device.port} device={device} onToggle={onToggle} />
         ))}
       </div>
-    </div>
-  );
-};
+    )}
+  </div>
+);
+
 export default UsbConfigTab;

--- a/src/features/apps/components/instances/tabs/VersionConfigTab.tsx
+++ b/src/features/apps/components/instances/tabs/VersionConfigTab.tsx
@@ -1,0 +1,85 @@
+import { useMemo, useState } from 'react';
+import VersionSelector from '@app/components/VersionSelector';
+import UpdateButton from '@features/apps/components/actions/UpdateButton';
+import type { AppVersion, EnrichedApp } from '@features/apps/types';
+
+interface VersionConfigTabProps {
+  app: EnrichedApp;
+  currentVersion: string;
+  versions: AppVersion[];
+}
+
+const VersionConfigTab = ({ app, currentVersion, versions }: VersionConfigTabProps) => {
+  const availableVersions = useMemo(() => {
+    const options = versions.some(({ version }) => version === currentVersion)
+      ? versions
+      : [...versions, { version: currentVersion, installed: true }];
+    const compare = new Intl.Collator('en', { numeric: true, sensitivity: 'base' }).compare;
+    return [...options].sort((a, b) => compare(b.version, a.version));
+  }, [currentVersion, versions]);
+  const [selectedVersion, setSelectedVersion] = useState<AppVersion>(
+    () =>
+      availableVersions.find(({ version }) => version === currentVersion) ??
+      availableVersions[0] ?? { version: currentVersion, installed: true },
+  );
+  const currentIndex = availableVersions.findIndex(({ version }) => version === currentVersion);
+  const selectedIndex = availableVersions.findIndex(
+    ({ version }) => version === selectedVersion.version,
+  );
+  const operation =
+    selectedVersion.version === currentVersion
+      ? undefined
+      : selectedIndex < currentIndex
+        ? 'update'
+        : 'downgrade';
+
+  return (
+    <div>
+      <div className="overflow-hidden rounded-2xl border border-border bg-surface-raised">
+        <div className="flex min-h-16 items-center gap-6 px-4 py-3.5">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-text-primary">Current version</p>
+            <p className="mt-0.5 text-xs text-muted">Installed on this instance</p>
+          </div>
+          <span className="shrink-0 font-mono text-sm font-semibold text-text-primary">
+            {currentVersion}
+          </span>
+        </div>
+        <div className="flex min-h-16 items-center gap-6 border-t border-border px-4 py-3.5">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-text-primary">Change version</p>
+            <p className="mt-0.5 text-xs text-muted">Choose a newer or older release</p>
+          </div>
+          <div className="w-64 shrink-0">
+            <VersionSelector
+              availableVersions={availableVersions}
+              selectedVersion={selectedVersion}
+              setSelectedVersion={setSelectedVersion}
+              currentVersion={currentVersion}
+              label="Target version"
+            />
+          </div>
+        </div>
+      </div>
+
+      {operation && (
+        <div className="mt-5 flex items-center justify-between gap-6">
+          <p className="text-sm text-text-secondary">
+            {operation === 'update'
+              ? 'Move this app and its instances to a newer version.'
+              : 'This moves this app and its instances to an older version.'}
+          </p>
+          <UpdateButton
+            app={app}
+            to={selectedVersion}
+            fromVersion={currentVersion}
+            operation={operation}
+            showSelectedVersion
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default VersionConfigTab;

--- a/src/features/apps/components/instances/useInstanceConfigDraft.ts
+++ b/src/features/apps/components/instances/useInstanceConfigDraft.ts
@@ -1,0 +1,322 @@
+import { useCallback, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import type {
+  InstanceEnvironmentVariable,
+  InstancePortMappingRange,
+  InstancePortMappingSingle,
+  InstancePorts,
+  TransportProtocol,
+  UsbDevice as SystemUsbDevice,
+  InstanceConfigUsbDevice,
+} from '@generated/core/schemas';
+import { TransportProtocol as Protocol } from '@generated/core/schemas';
+import {
+  getGetInstancesInstanceIdConfigDevicesUsbQueryKey,
+  getGetInstancesInstanceIdConfigEnvironmentQueryKey,
+  getGetInstancesInstanceIdConfigPortsQueryKey,
+  useDeleteInstancesInstanceIdConfigDevicesUsbPort,
+  useGetInstancesInstanceIdConfigDevicesUsb,
+  useGetInstancesInstanceIdConfigEnvironment,
+  useGetInstancesInstanceIdConfigPorts,
+  usePutInstancesInstanceIdConfigDevicesUsbPort,
+  usePutInstancesInstanceIdConfigEnvironment,
+  usePutInstancesInstanceIdConfigPortsTransportProtocol,
+} from '@generated/core/instances/instances';
+import {
+  getGetSystemDevicesUsbQueryKey,
+  useGetSystemDevicesUsb,
+} from '@generated/core/system/system';
+import { unwrapSuccess } from '@app/api/unwrap';
+
+export type DraftSection = 'usb' | 'ports' | 'env';
+
+export type EnvironmentDraft = InstanceEnvironmentVariable & { _rowId: string };
+
+export type PortDraft = {
+  protocol: TransportProtocol;
+  port: InstancePortMappingSingle | InstancePortMappingRange;
+  _rowId: string;
+};
+
+export type UsbDraft = {
+  port: string;
+  name: string;
+  vendor: string;
+  device_connected: boolean;
+  enabled: boolean;
+};
+
+type InstanceConfigDraft = {
+  environment: EnvironmentDraft[];
+  ports: PortDraft[];
+  usb: UsbDraft[];
+};
+
+const clone = <T>(value: T): T => structuredClone(value);
+const comparable = (value: unknown) => JSON.stringify(value);
+
+const environmentPayload = (rows: EnvironmentDraft[]): InstanceEnvironmentVariable[] =>
+  rows.map(({ name, value }) => ({ name: name.trim(), value }));
+
+const portsPayload = (rows: PortDraft[], protocol: TransportProtocol) =>
+  rows.filter((row) => row.protocol === protocol).map((row) => row.port);
+
+const createDraft = (
+  environment: InstanceEnvironmentVariable[],
+  ports: InstancePorts,
+  systemUsb: SystemUsbDevice[],
+  instanceUsb: InstanceConfigUsbDevice[],
+): InstanceConfigDraft => {
+  const usb: UsbDraft[] = systemUsb.map((device) => {
+    const configured = instanceUsb.find((item) => item.port === device.port);
+    return {
+      port: device.port,
+      name: device.name ?? 'Unknown',
+      vendor: device.vendor ?? 'Unknown',
+      device_connected: configured?.device_connected ?? true,
+      enabled: Boolean(configured),
+    };
+  });
+
+  instanceUsb.forEach((device) => {
+    if (usb.some((item) => item.port === device.port)) return;
+    usb.push({
+      port: device.port,
+      name: device.name ?? 'Unknown',
+      vendor: device.vendor ?? 'Unknown',
+      device_connected: false,
+      enabled: true,
+    });
+  });
+
+  return {
+    environment: environment.map((item) => ({ ...item, _rowId: crypto.randomUUID() })),
+    ports: ([Protocol.tcp, Protocol.udp, Protocol.sctp] as const).flatMap((protocol) =>
+      ports[protocol].map((port) => ({ protocol, port, _rowId: crypto.randomUUID() })),
+    ),
+    usb: usb.sort((a, b) => a.port.localeCompare(b.port)),
+  };
+};
+
+const validate = (draft: InstanceConfigDraft | null) => {
+  if (!draft) return undefined;
+
+  const names = draft.environment.map(({ name }) => name.trim());
+  if (names.some((name) => !name)) return 'Environment variable names cannot be empty.';
+  if (new Set(names).size !== names.length) return 'Environment variable names must be unique.';
+
+  const validPort = (value: number) => Number.isInteger(value) && value >= 1 && value <= 65535;
+  for (const { port } of draft.ports) {
+    if ('host_port' in port) {
+      if (!validPort(port.host_port) || !validPort(port.container_port)) {
+        return 'Ports must be between 1 and 65535.';
+      }
+      continue;
+    }
+    const hostSize = port.host_ports.end - port.host_ports.start;
+    const containerSize = port.container_ports.end - port.container_ports.start;
+    if (
+      !validPort(port.host_ports.start) ||
+      !validPort(port.host_ports.end) ||
+      !validPort(port.container_ports.start) ||
+      !validPort(port.container_ports.end) ||
+      hostSize < 0 ||
+      containerSize < 0
+    ) {
+      return 'Port ranges must use valid start and end values.';
+    }
+    if (hostSize !== containerSize) return 'Host and container port ranges must be the same size.';
+  }
+};
+
+export function useInstanceConfigDraft(instanceId: string) {
+  const queryClient = useQueryClient();
+  const environmentQuery = useGetInstancesInstanceIdConfigEnvironment(instanceId);
+  const portsQuery = useGetInstancesInstanceIdConfigPorts(instanceId);
+  const systemUsbQuery = useGetSystemDevicesUsb();
+  const instanceUsbQuery = useGetInstancesInstanceIdConfigDevicesUsb(instanceId);
+  const { mutateAsync: putEnvironment } = usePutInstancesInstanceIdConfigEnvironment();
+  const { mutateAsync: putPorts } = usePutInstancesInstanceIdConfigPortsTransportProtocol();
+  const { mutateAsync: enableUsb } = usePutInstancesInstanceIdConfigDevicesUsbPort();
+  const { mutateAsync: disableUsb } = useDeleteInstancesInstanceIdConfigDevicesUsbPort();
+  const [editedDraft, setEditedDraft] = useState<InstanceConfigDraft | null>(null);
+  const [savedDraft, setSavedDraft] = useState<InstanceConfigDraft | null>(null);
+
+  const serverDraft = useMemo(() => {
+    const environment = unwrapSuccess(environmentQuery.data);
+    const ports = unwrapSuccess(portsQuery.data);
+    const systemUsb = unwrapSuccess(systemUsbQuery.data);
+    const instanceUsb = unwrapSuccess(instanceUsbQuery.data);
+    if (!environment || !ports || !systemUsb || !instanceUsb) return null;
+    return createDraft(environment, ports, systemUsb, instanceUsb);
+  }, [environmentQuery.data, portsQuery.data, systemUsbQuery.data, instanceUsbQuery.data]);
+
+  const baseline = savedDraft ?? serverDraft;
+  const draft = editedDraft ?? baseline;
+
+  const dirtySections = useMemo(() => {
+    if (!baseline || !draft) return [] as DraftSection[];
+    const sections: DraftSection[] = [];
+    if (
+      comparable(environmentPayload(draft.environment)) !==
+      comparable(environmentPayload(baseline.environment))
+    )
+      sections.push('env');
+    if (
+      comparable(draft.ports.map(({ protocol, port }) => ({ protocol, port }))) !==
+      comparable(baseline.ports.map(({ protocol, port }) => ({ protocol, port })))
+    )
+      sections.push('ports');
+    if (
+      comparable(draft.usb.map(({ port, enabled }) => ({ port, enabled }))) !==
+      comparable(baseline.usb.map(({ port, enabled }) => ({ port, enabled })))
+    )
+      sections.push('usb');
+    return sections;
+  }, [baseline, draft]);
+
+  const freezeBaseline = useCallback(() => {
+    if (draft) setSavedDraft((current) => current ?? clone(draft));
+  }, [draft]);
+
+  const updateEnvironment = useCallback(
+    (update: (rows: EnvironmentDraft[]) => EnvironmentDraft[]) => {
+      freezeBaseline();
+      setEditedDraft((current) =>
+        current || draft
+          ? {
+              ...(current ?? clone(draft!)),
+              environment: update((current ?? draft!).environment),
+            }
+          : current,
+      );
+    },
+    [draft, freezeBaseline],
+  );
+  const updatePorts = useCallback(
+    (update: (rows: PortDraft[]) => PortDraft[]) => {
+      freezeBaseline();
+      setEditedDraft((current) =>
+        current || draft
+          ? { ...(current ?? clone(draft!)), ports: update((current ?? draft!).ports) }
+          : current,
+      );
+    },
+    [draft, freezeBaseline],
+  );
+  const toggleUsb = useCallback(
+    (port: string) => {
+      freezeBaseline();
+      setEditedDraft((current) =>
+        current || draft
+          ? {
+              ...(current ?? clone(draft!)),
+              usb: (current ?? draft!).usb.map((device) =>
+                device.port === port ? { ...device, enabled: !device.enabled } : device,
+              ),
+            }
+          : current,
+      );
+    },
+    [draft, freezeBaseline],
+  );
+
+  const reset = useCallback(() => {
+    setEditedDraft(null);
+  }, []);
+
+  const apply = useCallback(async () => {
+    if (!baseline || !draft) return;
+    const sections = new Set(dirtySections);
+
+    if (sections.has('env')) {
+      await putEnvironment({ instanceId, data: environmentPayload(draft.environment) });
+    }
+    if (sections.has('ports')) {
+      for (const protocol of [Protocol.tcp, Protocol.udp, Protocol.sctp]) {
+        if (
+          comparable(portsPayload(draft.ports, protocol)) ===
+          comparable(portsPayload(baseline.ports, protocol))
+        )
+          continue;
+        await putPorts({
+          instanceId,
+          transportProtocol: protocol,
+          data: portsPayload(draft.ports, protocol),
+        });
+      }
+    }
+    if (sections.has('usb')) {
+      for (const device of draft.usb) {
+        const previous = baseline.usb.find(({ port }) => port === device.port);
+        if (!previous || previous.enabled === device.enabled) continue;
+        if (device.enabled) await enableUsb({ instanceId, port: device.port });
+        else await disableUsb({ instanceId, port: device.port });
+      }
+    }
+
+    const saved = clone(draft);
+    setSavedDraft(saved);
+    setEditedDraft(null);
+    await Promise.all([
+      queryClient.invalidateQueries({
+        queryKey: getGetInstancesInstanceIdConfigEnvironmentQueryKey(instanceId),
+        refetchType: 'none',
+      }),
+      queryClient.invalidateQueries({
+        queryKey: getGetInstancesInstanceIdConfigPortsQueryKey(instanceId),
+        refetchType: 'none',
+      }),
+      queryClient.invalidateQueries({
+        queryKey: getGetInstancesInstanceIdConfigDevicesUsbQueryKey(instanceId),
+        refetchType: 'none',
+      }),
+      queryClient.invalidateQueries({
+        queryKey: getGetSystemDevicesUsbQueryKey(),
+        refetchType: 'none',
+      }),
+    ]);
+  }, [
+    baseline,
+    dirtySections,
+    disableUsb,
+    draft,
+    enableUsb,
+    instanceId,
+    putEnvironment,
+    putPorts,
+    queryClient,
+  ]);
+
+  const loading =
+    environmentQuery.isLoading ||
+    portsQuery.isLoading ||
+    systemUsbQuery.isLoading ||
+    instanceUsbQuery.isLoading;
+  const loadError =
+    environmentQuery.error || portsQuery.error || systemUsbQuery.error || instanceUsbQuery.error;
+  const reload = useCallback(
+    () =>
+      Promise.all([
+        environmentQuery.refetch(),
+        portsQuery.refetch(),
+        systemUsbQuery.refetch(),
+        instanceUsbQuery.refetch(),
+      ]),
+    [environmentQuery, instanceUsbQuery, portsQuery, systemUsbQuery],
+  );
+
+  return {
+    draft,
+    dirtySections,
+    validationError: validate(draft),
+    loading,
+    loadError,
+    updateEnvironment,
+    updatePorts,
+    toggleUsb,
+    reset,
+    apply,
+    reload,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -110,4 +110,14 @@
   body {
     @apply bg-surface text-text-primary font-sans antialiased;
   }
+
+  button:not(:disabled),
+  [role='button']:not([aria-disabled='true']) {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [role='button'][aria-disabled='true'] {
+    cursor: not-allowed;
+  }
 }


### PR DESCRIPTION
## Summary

- replace mixed row-level saves with one staged configuration workspace for Environment, Ports, and USB
- apply changes through one explicit Apply & restart action while preserving stopped instances and failed drafts
- modernize navigation, pointer feedback, USB switches, and the version update or downgrade experience
- use accessible native dialogs with safe dismissal and progressive review
- keep Network and Editors as immediate operations with consistent explanatory copy

## Safety and behavior

- configuration writes complete before lifecycle operations begin
- failed writes preserve the local draft and never restart the instance
- stopped instances remain stopped after configuration changes
- USB drafts survive background query refreshes
- downloaded versions are reused when downgrading
- dismiss actions never save or restart

## Verification

- npm test: 125 tests passed
- npm run build: passed after clean Orval regeneration
- Playwright TC23 instance configuration: 7 tests passed
- npm run lint: passed
- generated files and Orval configuration are unchanged